### PR TITLE
data: Added test report data for dragen coverage module

### DIFF
--- a/data/modules/dragen/pr_1880/read_me.txt
+++ b/data/modules/dragen/pr_1880/read_me.txt
@@ -1,0 +1,1 @@
+Artificial coverage_metrics.csv and overall_mean_cov.csv files.

--- a/data/modules/dragen/pr_1880/sample_0.qc-coverage-region-1_coverage_metrics.csv
+++ b/data/modules/dragen/pr_1880/sample_0.qc-coverage-region-1_coverage_metrics.csv
@@ -1,0 +1,33 @@
+COVERAGE SUMMARY,,Aligned bases,3203799614
+COVERAGE SUMMARY,,Aligned bases in QC coverage region,3641121654,81.63
+COVERAGE SUMMARY,,Average alignment coverage over QC coverage region,34.85
+COVERAGE SUMMARY,,Uniformity of coverage (PCT > 0.2*mean) over QC coverage region,56.88
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1500x: inf),0.008
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1000x: inf),0.012
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 500x: inf),0.021
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 100x: inf),0.039
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  50x: inf),4.13
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  20x: inf),50.25
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  15x: inf),61.05
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  10x: inf),74.21
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   3x: inf),86.55
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   1x: inf),99.96
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   0x: inf),100.00
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1000x:1500x),0.0009
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 500x:1000x),0.0007
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 100x: 500x),0.0001
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  50x: 100x),0.91
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  20x:  50x),0.82
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  15x:  20x),0.94
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  10x:  15x),0.55
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   3x:  10x),0.74
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   1x:   3x),0.1
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   0x:   1x),0.003
+COVERAGE SUMMARY,,Average chr X coverage over QC coverage region,106.85
+COVERAGE SUMMARY,,Average chr Y coverage over QC coverage region,91.97
+COVERAGE SUMMARY,,Average mitochondrial coverage over QC coverage region,37.4
+COVERAGE SUMMARY,,Average autosomal coverage over QC coverage region,42.78
+COVERAGE SUMMARY,,Median autosomal coverage over QC coverage region,47.02
+COVERAGE SUMMARY,,Mean/Median autosomal coverage ratio over QC coverage region,96.12
+COVERAGE SUMMARY,,Aligned reads,2847205512
+COVERAGE SUMMARY,,Aligned reads in QC coverage region,2958440055,21.71

--- a/data/modules/dragen/pr_1880/sample_0.qc-coverage-region-1_overall_mean_cov.csv
+++ b/data/modules/dragen/pr_1880/sample_0.qc-coverage-region-1_overall_mean_cov.csv
@@ -1,0 +1,1 @@
+Average alignment coverage over C:/path/to/QC_1.bed,0.25

--- a/data/modules/dragen/pr_1880/sample_0.qc-coverage-region-2_coverage_metrics.csv
+++ b/data/modules/dragen/pr_1880/sample_0.qc-coverage-region-2_coverage_metrics.csv
@@ -1,0 +1,33 @@
+COVERAGE SUMMARY,,Aligned bases,2946670263
+COVERAGE SUMMARY,,Aligned bases in QC coverage region,2715483017,8.56
+COVERAGE SUMMARY,,Average alignment coverage over QC coverage region,27.64
+COVERAGE SUMMARY,,Uniformity of coverage (PCT > 0.2*mean) over QC coverage region,38.82
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1500x: inf),0.006
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1000x: inf),0.019
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 500x: inf),0.023
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 100x: inf),0.03
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  50x: inf),4.75
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  20x: inf),56.14
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  15x: inf),65.14
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  10x: inf),79.34
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   3x: inf),84.18
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   1x: inf),99.97
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   0x: inf),100.00
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1000x:1500x),0.0001
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 500x:1000x),0.0004
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 100x: 500x),0.0007
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  50x: 100x),0.72
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  20x:  50x),0.81
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  15x:  20x),0.76
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  10x:  15x),0.88
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   3x:  10x),0.44
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   1x:   3x),0.16
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   0x:   1x),0.01
+COVERAGE SUMMARY,,Average chr X coverage over QC coverage region,94.78
+COVERAGE SUMMARY,,Average chr Y coverage over QC coverage region,118.68
+COVERAGE SUMMARY,,Average mitochondrial coverage over QC coverage region,23.8
+COVERAGE SUMMARY,,Average autosomal coverage over QC coverage region,25.64
+COVERAGE SUMMARY,,Median autosomal coverage over QC coverage region,49.91
+COVERAGE SUMMARY,,Mean/Median autosomal coverage ratio over QC coverage region,15.67
+COVERAGE SUMMARY,,Aligned reads,2124858553
+COVERAGE SUMMARY,,Aligned reads in QC coverage region,2763882560,77.43

--- a/data/modules/dragen/pr_1880/sample_0.qc-coverage-region-2_overall_mean_cov.csv
+++ b/data/modules/dragen/pr_1880/sample_0.qc-coverage-region-2_overall_mean_cov.csv
@@ -1,0 +1,1 @@
+Average alignment coverage over C:/path/to/QC_2.bed,0.25

--- a/data/modules/dragen/pr_1880/sample_0.target_bed_coverage_metrics.csv
+++ b/data/modules/dragen/pr_1880/sample_0.target_bed_coverage_metrics.csv
@@ -1,0 +1,33 @@
+COVERAGE SUMMARY,,Aligned bases,2893234893
+COVERAGE SUMMARY,,Aligned bases in target bed,1293045769,63.21
+COVERAGE SUMMARY,,Average alignment coverage over target bed,34.27
+COVERAGE SUMMARY,,Uniformity of coverage (PCT > 0.2*mean) over target bed,52.65
+COVERAGE SUMMARY,,PCT of target bed with coverage [1500x: inf),0.004
+COVERAGE SUMMARY,,PCT of target bed with coverage [1000x: inf),0.02
+COVERAGE SUMMARY,,PCT of target bed with coverage [ 500x: inf),0.026
+COVERAGE SUMMARY,,PCT of target bed with coverage [ 100x: inf),0.038
+COVERAGE SUMMARY,,PCT of target bed with coverage [  50x: inf),4.84
+COVERAGE SUMMARY,,PCT of target bed with coverage [  20x: inf),53.34
+COVERAGE SUMMARY,,PCT of target bed with coverage [  15x: inf),62.96
+COVERAGE SUMMARY,,PCT of target bed with coverage [  10x: inf),72.13
+COVERAGE SUMMARY,,PCT of target bed with coverage [   3x: inf),88.34
+COVERAGE SUMMARY,,PCT of target bed with coverage [   1x: inf),96.96
+COVERAGE SUMMARY,,PCT of target bed with coverage [   0x: inf),100.00
+COVERAGE SUMMARY,,PCT of target bed with coverage [1000x:1500x),0.001
+COVERAGE SUMMARY,,PCT of target bed with coverage [ 500x:1000x),0.0007
+COVERAGE SUMMARY,,PCT of target bed with coverage [ 100x: 500x),0.0008
+COVERAGE SUMMARY,,PCT of target bed with coverage [  50x: 100x),0.93
+COVERAGE SUMMARY,,PCT of target bed with coverage [  20x:  50x),0.79
+COVERAGE SUMMARY,,PCT of target bed with coverage [  15x:  20x),0.55
+COVERAGE SUMMARY,,PCT of target bed with coverage [  10x:  15x),0.56
+COVERAGE SUMMARY,,PCT of target bed with coverage [   3x:  10x),0.92
+COVERAGE SUMMARY,,PCT of target bed with coverage [   1x:   3x),0.12
+COVERAGE SUMMARY,,PCT of target bed with coverage [   0x:   1x),0.002
+COVERAGE SUMMARY,,Average chr X coverage over target bed,47.69
+COVERAGE SUMMARY,,Average chr Y coverage over target bed,35.95
+COVERAGE SUMMARY,,Average mitochondrial coverage over target bed,25.2
+COVERAGE SUMMARY,,Average autosomal coverage over target bed,32.32
+COVERAGE SUMMARY,,Median autosomal coverage over target bed,21.29
+COVERAGE SUMMARY,,Mean/Median autosomal coverage ratio over target bed,62.24
+COVERAGE SUMMARY,,Aligned reads,1893972640
+COVERAGE SUMMARY,,Aligned reads in target bed,2299894892,58.29

--- a/data/modules/dragen/pr_1880/sample_0.target_bed_overall_mean_cov.csv
+++ b/data/modules/dragen/pr_1880/sample_0.target_bed_overall_mean_cov.csv
@@ -1,0 +1,1 @@
+Average alignment coverage over C:/path/to/very_special_region.bed,0.04

--- a/data/modules/dragen/pr_1880/sample_0.wgs_coverage_metrics.csv
+++ b/data/modules/dragen/pr_1880/sample_0.wgs_coverage_metrics.csv
@@ -1,0 +1,33 @@
+COVERAGE SUMMARY,,Aligned bases,2461606803
+COVERAGE SUMMARY,,Aligned bases in genome,2359893297,3.11
+COVERAGE SUMMARY,,Average alignment coverage over genome,91.15
+COVERAGE SUMMARY,,Uniformity of coverage (PCT > 0.2*mean) over genome,81.17
+COVERAGE SUMMARY,,PCT of genome with coverage [1500x: inf),0.004
+COVERAGE SUMMARY,,PCT of genome with coverage [1000x: inf),0.019
+COVERAGE SUMMARY,,PCT of genome with coverage [ 500x: inf),0.023
+COVERAGE SUMMARY,,PCT of genome with coverage [ 100x: inf),0.038
+COVERAGE SUMMARY,,PCT of genome with coverage [  50x: inf),4.32
+COVERAGE SUMMARY,,PCT of genome with coverage [  20x: inf),50.93
+COVERAGE SUMMARY,,PCT of genome with coverage [  15x: inf),69.88
+COVERAGE SUMMARY,,PCT of genome with coverage [  10x: inf),71.57
+COVERAGE SUMMARY,,PCT of genome with coverage [   3x: inf),88.02
+COVERAGE SUMMARY,,PCT of genome with coverage [   1x: inf),93.11
+COVERAGE SUMMARY,,PCT of genome with coverage [   0x: inf),100.00
+COVERAGE SUMMARY,,PCT of genome with coverage [1000x:1500x),0.0
+COVERAGE SUMMARY,,PCT of genome with coverage [ 500x:1000x),0.001
+COVERAGE SUMMARY,,PCT of genome with coverage [ 100x: 500x),0.0001
+COVERAGE SUMMARY,,PCT of genome with coverage [  50x: 100x),0.78
+COVERAGE SUMMARY,,PCT of genome with coverage [  20x:  50x),0.56
+COVERAGE SUMMARY,,PCT of genome with coverage [  15x:  20x),0.58
+COVERAGE SUMMARY,,PCT of genome with coverage [  10x:  15x),0.44
+COVERAGE SUMMARY,,PCT of genome with coverage [   3x:  10x),0.94
+COVERAGE SUMMARY,,PCT of genome with coverage [   1x:   3x),0.19
+COVERAGE SUMMARY,,PCT of genome with coverage [   0x:   1x),0.006
+COVERAGE SUMMARY,,Average chr X coverage over genome,64.41
+COVERAGE SUMMARY,,Average chr Y coverage over genome,55.9
+COVERAGE SUMMARY,,Average mitochondrial coverage over genome,25.1
+COVERAGE SUMMARY,,Average autosomal coverage over genome,77.22
+COVERAGE SUMMARY,,Median autosomal coverage over genome,45.84
+COVERAGE SUMMARY,,Mean/Median autosomal coverage ratio over genome,76.52
+COVERAGE SUMMARY,,Aligned reads,2316127540
+COVERAGE SUMMARY,,Aligned reads in genome,1882984161,64.45

--- a/data/modules/dragen/pr_1880/sample_0.wgs_overall_mean_cov.csv
+++ b/data/modules/dragen/pr_1880/sample_0.wgs_overall_mean_cov.csv
@@ -1,0 +1,1 @@
+Average alignment coverage over C:/path/to/Whole_genome_756,0.92

--- a/data/modules/dragen/pr_1880/sample_1.qc-coverage-region-1_coverage_metrics.csv
+++ b/data/modules/dragen/pr_1880/sample_1.qc-coverage-region-1_coverage_metrics.csv
@@ -1,0 +1,33 @@
+COVERAGE SUMMARY,,Aligned bases,2259848749
+COVERAGE SUMMARY,,Aligned bases in QC coverage region,3606773472,98.55
+COVERAGE SUMMARY,,Average alignment coverage over QC coverage region,38.43
+COVERAGE SUMMARY,,Uniformity of coverage (PCT > 0.2*mean) over QC coverage region,98.21
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1500x: inf),0.002
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1000x: inf),0.018
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 500x: inf),0.029
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 100x: inf),0.031
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  50x: inf),4.27
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  20x: inf),55.01
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  15x: inf),66.28
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  10x: inf),77.2
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   3x: inf),84.88
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   1x: inf),91.22
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   0x: inf),100.00
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1000x:1500x),0.0007
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 500x:1000x),0.0003
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 100x: 500x),0.0006
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  50x: 100x),0.68
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  20x:  50x),0.5
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  15x:  20x),0.43
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  10x:  15x),0.73
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   3x:  10x),0.2
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   1x:   3x),0.16
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   0x:   1x),0.004
+COVERAGE SUMMARY,,Average chr X coverage over QC coverage region,53.38
+COVERAGE SUMMARY,,Average chr Y coverage over QC coverage region,25.04
+COVERAGE SUMMARY,,Average mitochondrial coverage over QC coverage region,62.8
+COVERAGE SUMMARY,,Average autosomal coverage over QC coverage region,5.52
+COVERAGE SUMMARY,,Median autosomal coverage over QC coverage region,30.81
+COVERAGE SUMMARY,,Mean/Median autosomal coverage ratio over QC coverage region,61.82
+COVERAGE SUMMARY,,Aligned reads,3389256695
+COVERAGE SUMMARY,,Aligned reads in QC coverage region,3018211123,55.5

--- a/data/modules/dragen/pr_1880/sample_1.qc-coverage-region-1_overall_mean_cov.csv
+++ b/data/modules/dragen/pr_1880/sample_1.qc-coverage-region-1_overall_mean_cov.csv
@@ -1,0 +1,1 @@
+Average alignment coverage over C:/path/to/QC_1.bed,0.35

--- a/data/modules/dragen/pr_1880/sample_1.qc-coverage-region-2_coverage_metrics.csv
+++ b/data/modules/dragen/pr_1880/sample_1.qc-coverage-region-2_coverage_metrics.csv
@@ -1,0 +1,33 @@
+COVERAGE SUMMARY,,Aligned bases,3346711556
+COVERAGE SUMMARY,,Aligned bases in QC coverage region,2623854005,90.62
+COVERAGE SUMMARY,,Average alignment coverage over QC coverage region,93.34
+COVERAGE SUMMARY,,Uniformity of coverage (PCT > 0.2*mean) over QC coverage region,45.08
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1500x: inf),0.005
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1000x: inf),0.012
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 500x: inf),0.028
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 100x: inf),0.031
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  50x: inf),4.03
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  20x: inf),55.43
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  15x: inf),62.13
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  10x: inf),72.39
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   3x: inf),83.49
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   1x: inf),93.88
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   0x: inf),100.00
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1000x:1500x),0.0004
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 500x:1000x),0.001
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 100x: 500x),0.0007
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  50x: 100x),0.94
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  20x:  50x),0.99
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  15x:  20x),0.71
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  10x:  15x),0.49
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   3x:  10x),0.47
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   1x:   3x),0.19
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   0x:   1x),0.004
+COVERAGE SUMMARY,,Average chr X coverage over QC coverage region,52.57
+COVERAGE SUMMARY,,Average chr Y coverage over QC coverage region,64.51
+COVERAGE SUMMARY,,Average mitochondrial coverage over QC coverage region,69.8
+COVERAGE SUMMARY,,Average autosomal coverage over QC coverage region,92.83
+COVERAGE SUMMARY,,Median autosomal coverage over QC coverage region,9.02
+COVERAGE SUMMARY,,Mean/Median autosomal coverage ratio over QC coverage region,15.63
+COVERAGE SUMMARY,,Aligned reads,1787901960
+COVERAGE SUMMARY,,Aligned reads in QC coverage region,2174401483,66.19

--- a/data/modules/dragen/pr_1880/sample_1.qc-coverage-region-2_overall_mean_cov.csv
+++ b/data/modules/dragen/pr_1880/sample_1.qc-coverage-region-2_overall_mean_cov.csv
@@ -1,0 +1,1 @@
+Average alignment coverage over C:/path/to/QC_2.bed,0.32

--- a/data/modules/dragen/pr_1880/sample_1.target_bed_coverage_metrics.csv
+++ b/data/modules/dragen/pr_1880/sample_1.target_bed_coverage_metrics.csv
@@ -1,0 +1,33 @@
+COVERAGE SUMMARY,,Aligned bases,2361766274
+COVERAGE SUMMARY,,Aligned bases in target bed,3366208386,37.34
+COVERAGE SUMMARY,,Average alignment coverage over target bed,62.22
+COVERAGE SUMMARY,,Uniformity of coverage (PCT > 0.2*mean) over target bed,26.93
+COVERAGE SUMMARY,,PCT of target bed with coverage [1500x: inf),0.009
+COVERAGE SUMMARY,,PCT of target bed with coverage [1000x: inf),0.019
+COVERAGE SUMMARY,,PCT of target bed with coverage [ 500x: inf),0.021
+COVERAGE SUMMARY,,PCT of target bed with coverage [ 100x: inf),0.039
+COVERAGE SUMMARY,,PCT of target bed with coverage [  50x: inf),4.76
+COVERAGE SUMMARY,,PCT of target bed with coverage [  20x: inf),50.12
+COVERAGE SUMMARY,,PCT of target bed with coverage [  15x: inf),60.26
+COVERAGE SUMMARY,,PCT of target bed with coverage [  10x: inf),76.29
+COVERAGE SUMMARY,,PCT of target bed with coverage [   3x: inf),81.25
+COVERAGE SUMMARY,,PCT of target bed with coverage [   1x: inf),98.78
+COVERAGE SUMMARY,,PCT of target bed with coverage [   0x: inf),100.00
+COVERAGE SUMMARY,,PCT of target bed with coverage [1000x:1500x),0.0006
+COVERAGE SUMMARY,,PCT of target bed with coverage [ 500x:1000x),0.0004
+COVERAGE SUMMARY,,PCT of target bed with coverage [ 100x: 500x),0.0003
+COVERAGE SUMMARY,,PCT of target bed with coverage [  50x: 100x),0.87
+COVERAGE SUMMARY,,PCT of target bed with coverage [  20x:  50x),0.58
+COVERAGE SUMMARY,,PCT of target bed with coverage [  15x:  20x),0.98
+COVERAGE SUMMARY,,PCT of target bed with coverage [  10x:  15x),0.75
+COVERAGE SUMMARY,,PCT of target bed with coverage [   3x:  10x),0.63
+COVERAGE SUMMARY,,PCT of target bed with coverage [   1x:   3x),0.2
+COVERAGE SUMMARY,,PCT of target bed with coverage [   0x:   1x),0.009
+COVERAGE SUMMARY,,Average chr X coverage over target bed,78.13
+COVERAGE SUMMARY,,Average chr Y coverage over target bed,102.29
+COVERAGE SUMMARY,,Average mitochondrial coverage over target bed,34.7
+COVERAGE SUMMARY,,Average autosomal coverage over target bed,39.82
+COVERAGE SUMMARY,,Median autosomal coverage over target bed,45.1
+COVERAGE SUMMARY,,Mean/Median autosomal coverage ratio over target bed,67.84
+COVERAGE SUMMARY,,Aligned reads,2495730726
+COVERAGE SUMMARY,,Aligned reads in target bed,1161249079,5.98

--- a/data/modules/dragen/pr_1880/sample_1.target_bed_overall_mean_cov.csv
+++ b/data/modules/dragen/pr_1880/sample_1.target_bed_overall_mean_cov.csv
@@ -1,0 +1,1 @@
+Average alignment coverage over C:/path/to/very_special_region.bed,0.91

--- a/data/modules/dragen/pr_1880/sample_1.wgs_coverage_metrics.csv
+++ b/data/modules/dragen/pr_1880/sample_1.wgs_coverage_metrics.csv
@@ -1,0 +1,33 @@
+COVERAGE SUMMARY,,Aligned bases,1351016290
+COVERAGE SUMMARY,,Aligned bases in genome,3092855543,71.79
+COVERAGE SUMMARY,,Average alignment coverage over genome,49.02
+COVERAGE SUMMARY,,Uniformity of coverage (PCT > 0.2*mean) over genome,90.7
+COVERAGE SUMMARY,,PCT of genome with coverage [1500x: inf),0.01
+COVERAGE SUMMARY,,PCT of genome with coverage [1000x: inf),0.012
+COVERAGE SUMMARY,,PCT of genome with coverage [ 500x: inf),0.03
+COVERAGE SUMMARY,,PCT of genome with coverage [ 100x: inf),0.037
+COVERAGE SUMMARY,,PCT of genome with coverage [  50x: inf),4.52
+COVERAGE SUMMARY,,PCT of genome with coverage [  20x: inf),55.85
+COVERAGE SUMMARY,,PCT of genome with coverage [  15x: inf),67.65
+COVERAGE SUMMARY,,PCT of genome with coverage [  10x: inf),76.44
+COVERAGE SUMMARY,,PCT of genome with coverage [   3x: inf),88.07
+COVERAGE SUMMARY,,PCT of genome with coverage [   1x: inf),90.31
+COVERAGE SUMMARY,,PCT of genome with coverage [   0x: inf),100.00
+COVERAGE SUMMARY,,PCT of genome with coverage [1000x:1500x),0.0002
+COVERAGE SUMMARY,,PCT of genome with coverage [ 500x:1000x),0.0
+COVERAGE SUMMARY,,PCT of genome with coverage [ 100x: 500x),0.0003
+COVERAGE SUMMARY,,PCT of genome with coverage [  50x: 100x),0.58
+COVERAGE SUMMARY,,PCT of genome with coverage [  20x:  50x),0.47
+COVERAGE SUMMARY,,PCT of genome with coverage [  15x:  20x),0.9
+COVERAGE SUMMARY,,PCT of genome with coverage [  10x:  15x),0.47
+COVERAGE SUMMARY,,PCT of genome with coverage [   3x:  10x),0.53
+COVERAGE SUMMARY,,PCT of genome with coverage [   1x:   3x),0.13
+COVERAGE SUMMARY,,PCT of genome with coverage [   0x:   1x),0.007
+COVERAGE SUMMARY,,Average chr X coverage over genome,35.86
+COVERAGE SUMMARY,,Average chr Y coverage over genome,69.19
+COVERAGE SUMMARY,,Average mitochondrial coverage over genome,39.9
+COVERAGE SUMMARY,,Average autosomal coverage over genome,25.33
+COVERAGE SUMMARY,,Median autosomal coverage over genome,76.76
+COVERAGE SUMMARY,,Mean/Median autosomal coverage ratio over genome,62.69
+COVERAGE SUMMARY,,Aligned reads,1359749411
+COVERAGE SUMMARY,,Aligned reads in genome,1014219778,10.06

--- a/data/modules/dragen/pr_1880/sample_1.wgs_overall_mean_cov.csv
+++ b/data/modules/dragen/pr_1880/sample_1.wgs_overall_mean_cov.csv
@@ -1,0 +1,1 @@
+Average alignment coverage over C:/path/to/Whole_genome_756,0.18

--- a/data/modules/dragen/pr_1880/sample_2.qc-coverage-region-1_coverage_metrics.csv
+++ b/data/modules/dragen/pr_1880/sample_2.qc-coverage-region-1_coverage_metrics.csv
@@ -1,0 +1,33 @@
+COVERAGE SUMMARY,,Aligned bases,3303553216
+COVERAGE SUMMARY,,Aligned bases in QC coverage region,2982342232,83.6
+COVERAGE SUMMARY,,Average alignment coverage over QC coverage region,4.45
+COVERAGE SUMMARY,,Uniformity of coverage (PCT > 0.2*mean) over QC coverage region,35.91
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1500x: inf),0.004
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1000x: inf),0.017
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 500x: inf),0.027
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 100x: inf),0.036
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  50x: inf),4.29
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  20x: inf),59.15
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  15x: inf),68.3
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  10x: inf),75.07
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   3x: inf),85.08
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   1x: inf),95.12
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   0x: inf),100.00
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1000x:1500x),0.0006
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 500x:1000x),0.0009
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 100x: 500x),0.0004
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  50x: 100x),0.49
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  20x:  50x),0.44
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  15x:  20x),0.49
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  10x:  15x),0.48
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   3x:  10x),0.48
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   1x:   3x),0.11
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   0x:   1x),0.01
+COVERAGE SUMMARY,,Average chr X coverage over QC coverage region,70.79
+COVERAGE SUMMARY,,Average chr Y coverage over QC coverage region,116.4
+COVERAGE SUMMARY,,Average mitochondrial coverage over QC coverage region,48.0
+COVERAGE SUMMARY,,Average autosomal coverage over QC coverage region,36.8
+COVERAGE SUMMARY,,Median autosomal coverage over QC coverage region,83.82
+COVERAGE SUMMARY,,Mean/Median autosomal coverage ratio over QC coverage region,71.63
+COVERAGE SUMMARY,,Aligned reads,1529027969
+COVERAGE SUMMARY,,Aligned reads in QC coverage region,3914597434,18.74

--- a/data/modules/dragen/pr_1880/sample_2.qc-coverage-region-1_overall_mean_cov.csv
+++ b/data/modules/dragen/pr_1880/sample_2.qc-coverage-region-1_overall_mean_cov.csv
@@ -1,0 +1,1 @@
+Average alignment coverage over C:/path/to/QC_1.bed,0.27

--- a/data/modules/dragen/pr_1880/sample_2.qc-coverage-region-2_coverage_metrics.csv
+++ b/data/modules/dragen/pr_1880/sample_2.qc-coverage-region-2_coverage_metrics.csv
@@ -1,0 +1,33 @@
+COVERAGE SUMMARY,,Aligned bases,3105193024
+COVERAGE SUMMARY,,Aligned bases in QC coverage region,3278991650,11.29
+COVERAGE SUMMARY,,Average alignment coverage over QC coverage region,33.73
+COVERAGE SUMMARY,,Uniformity of coverage (PCT > 0.2*mean) over QC coverage region,1.66
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1500x: inf),0.006
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1000x: inf),0.013
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 500x: inf),0.028
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 100x: inf),0.038
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  50x: inf),4.66
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  20x: inf),57.67
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  15x: inf),61.15
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  10x: inf),73.05
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   3x: inf),89.8
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   1x: inf),90.59
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   0x: inf),100.00
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1000x:1500x),0.0007
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 500x:1000x),0.0002
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 100x: 500x),0.0
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  50x: 100x),0.49
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  20x:  50x),0.54
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  15x:  20x),0.9
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  10x:  15x),0.4
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   3x:  10x),0.32
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   1x:   3x),0.2
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   0x:   1x),0.0
+COVERAGE SUMMARY,,Average chr X coverage over QC coverage region,47.93
+COVERAGE SUMMARY,,Average chr Y coverage over QC coverage region,98.55
+COVERAGE SUMMARY,,Average mitochondrial coverage over QC coverage region,97.5
+COVERAGE SUMMARY,,Average autosomal coverage over QC coverage region,24.31
+COVERAGE SUMMARY,,Median autosomal coverage over QC coverage region,45.17
+COVERAGE SUMMARY,,Mean/Median autosomal coverage ratio over QC coverage region,44.94
+COVERAGE SUMMARY,,Aligned reads,1401507762
+COVERAGE SUMMARY,,Aligned reads in QC coverage region,1469086381,20.92

--- a/data/modules/dragen/pr_1880/sample_2.qc-coverage-region-2_overall_mean_cov.csv
+++ b/data/modules/dragen/pr_1880/sample_2.qc-coverage-region-2_overall_mean_cov.csv
@@ -1,0 +1,1 @@
+Average alignment coverage over C:/path/to/QC_2.bed,0.4

--- a/data/modules/dragen/pr_1880/sample_2.target_bed_coverage_metrics.csv
+++ b/data/modules/dragen/pr_1880/sample_2.target_bed_coverage_metrics.csv
@@ -1,0 +1,33 @@
+COVERAGE SUMMARY,,Aligned bases,2054718348
+COVERAGE SUMMARY,,Aligned bases in target bed,3153039131,92.72
+COVERAGE SUMMARY,,Average alignment coverage over target bed,43.32
+COVERAGE SUMMARY,,Uniformity of coverage (PCT > 0.2*mean) over target bed,12.96
+COVERAGE SUMMARY,,PCT of target bed with coverage [1500x: inf),0.002
+COVERAGE SUMMARY,,PCT of target bed with coverage [1000x: inf),0.018
+COVERAGE SUMMARY,,PCT of target bed with coverage [ 500x: inf),0.022
+COVERAGE SUMMARY,,PCT of target bed with coverage [ 100x: inf),0.04
+COVERAGE SUMMARY,,PCT of target bed with coverage [  50x: inf),4.35
+COVERAGE SUMMARY,,PCT of target bed with coverage [  20x: inf),54.45
+COVERAGE SUMMARY,,PCT of target bed with coverage [  15x: inf),60.52
+COVERAGE SUMMARY,,PCT of target bed with coverage [  10x: inf),75.36
+COVERAGE SUMMARY,,PCT of target bed with coverage [   3x: inf),86.41
+COVERAGE SUMMARY,,PCT of target bed with coverage [   1x: inf),98.96
+COVERAGE SUMMARY,,PCT of target bed with coverage [   0x: inf),100.00
+COVERAGE SUMMARY,,PCT of target bed with coverage [1000x:1500x),0.0009
+COVERAGE SUMMARY,,PCT of target bed with coverage [ 500x:1000x),0.001
+COVERAGE SUMMARY,,PCT of target bed with coverage [ 100x: 500x),0.0007
+COVERAGE SUMMARY,,PCT of target bed with coverage [  50x: 100x),0.69
+COVERAGE SUMMARY,,PCT of target bed with coverage [  20x:  50x),0.65
+COVERAGE SUMMARY,,PCT of target bed with coverage [  15x:  20x),0.69
+COVERAGE SUMMARY,,PCT of target bed with coverage [  10x:  15x),0.73
+COVERAGE SUMMARY,,PCT of target bed with coverage [   3x:  10x),0.2
+COVERAGE SUMMARY,,PCT of target bed with coverage [   1x:   3x),0.11
+COVERAGE SUMMARY,,PCT of target bed with coverage [   0x:   1x),0.0
+COVERAGE SUMMARY,,Average chr X coverage over target bed,63.85
+COVERAGE SUMMARY,,Average chr Y coverage over target bed,27.76
+COVERAGE SUMMARY,,Average mitochondrial coverage over target bed,94.1
+COVERAGE SUMMARY,,Average autosomal coverage over target bed,49.84
+COVERAGE SUMMARY,,Median autosomal coverage over target bed,59.43
+COVERAGE SUMMARY,,Mean/Median autosomal coverage ratio over target bed,76.65
+COVERAGE SUMMARY,,Aligned reads,1821559415
+COVERAGE SUMMARY,,Aligned reads in target bed,3053947728,53.02

--- a/data/modules/dragen/pr_1880/sample_2.target_bed_overall_mean_cov.csv
+++ b/data/modules/dragen/pr_1880/sample_2.target_bed_overall_mean_cov.csv
@@ -1,0 +1,1 @@
+Average alignment coverage over C:/path/to/very_special_region.bed,0.5

--- a/data/modules/dragen/pr_1880/sample_2.wgs_coverage_metrics.csv
+++ b/data/modules/dragen/pr_1880/sample_2.wgs_coverage_metrics.csv
@@ -1,0 +1,33 @@
+COVERAGE SUMMARY,,Aligned bases,3655209038
+COVERAGE SUMMARY,,Aligned bases in genome,3502950272,38.35
+COVERAGE SUMMARY,,Average alignment coverage over genome,23.45
+COVERAGE SUMMARY,,Uniformity of coverage (PCT > 0.2*mean) over genome,28.7
+COVERAGE SUMMARY,,PCT of genome with coverage [1500x: inf),0.006
+COVERAGE SUMMARY,,PCT of genome with coverage [1000x: inf),0.014
+COVERAGE SUMMARY,,PCT of genome with coverage [ 500x: inf),0.027
+COVERAGE SUMMARY,,PCT of genome with coverage [ 100x: inf),0.038
+COVERAGE SUMMARY,,PCT of genome with coverage [  50x: inf),4.0
+COVERAGE SUMMARY,,PCT of genome with coverage [  20x: inf),58.58
+COVERAGE SUMMARY,,PCT of genome with coverage [  15x: inf),61.28
+COVERAGE SUMMARY,,PCT of genome with coverage [  10x: inf),74.71
+COVERAGE SUMMARY,,PCT of genome with coverage [   3x: inf),85.61
+COVERAGE SUMMARY,,PCT of genome with coverage [   1x: inf),98.65
+COVERAGE SUMMARY,,PCT of genome with coverage [   0x: inf),100.00
+COVERAGE SUMMARY,,PCT of genome with coverage [1000x:1500x),0.0003
+COVERAGE SUMMARY,,PCT of genome with coverage [ 500x:1000x),0.0005
+COVERAGE SUMMARY,,PCT of genome with coverage [ 100x: 500x),0.0009
+COVERAGE SUMMARY,,PCT of genome with coverage [  50x: 100x),0.55
+COVERAGE SUMMARY,,PCT of genome with coverage [  20x:  50x),0.81
+COVERAGE SUMMARY,,PCT of genome with coverage [  15x:  20x),0.96
+COVERAGE SUMMARY,,PCT of genome with coverage [  10x:  15x),0.73
+COVERAGE SUMMARY,,PCT of genome with coverage [   3x:  10x),0.31
+COVERAGE SUMMARY,,PCT of genome with coverage [   1x:   3x),0.19
+COVERAGE SUMMARY,,PCT of genome with coverage [   0x:   1x),0.01
+COVERAGE SUMMARY,,Average chr X coverage over genome,24.59
+COVERAGE SUMMARY,,Average chr Y coverage over genome,26.84
+COVERAGE SUMMARY,,Average mitochondrial coverage over genome,55.9
+COVERAGE SUMMARY,,Average autosomal coverage over genome,94.55
+COVERAGE SUMMARY,,Median autosomal coverage over genome,76.49
+COVERAGE SUMMARY,,Mean/Median autosomal coverage ratio over genome,51.0
+COVERAGE SUMMARY,,Aligned reads,1176752305
+COVERAGE SUMMARY,,Aligned reads in genome,2251592403,46.89

--- a/data/modules/dragen/pr_1880/sample_2.wgs_overall_mean_cov.csv
+++ b/data/modules/dragen/pr_1880/sample_2.wgs_overall_mean_cov.csv
@@ -1,0 +1,1 @@
+Average alignment coverage over C:/path/to/Whole_genome_756,0.41

--- a/data/modules/dragen/pr_1880/sample_3.qc-coverage-region-1_coverage_metrics.csv
+++ b/data/modules/dragen/pr_1880/sample_3.qc-coverage-region-1_coverage_metrics.csv
@@ -1,0 +1,33 @@
+COVERAGE SUMMARY,,Aligned bases,2175344916
+COVERAGE SUMMARY,,Aligned bases in QC coverage region,3515603172,17.01
+COVERAGE SUMMARY,,Average alignment coverage over QC coverage region,97.0
+COVERAGE SUMMARY,,Uniformity of coverage (PCT > 0.2*mean) over QC coverage region,35.19
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1500x: inf),0.007
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1000x: inf),0.02
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 500x: inf),0.022
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 100x: inf),0.033
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  50x: inf),4.23
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  20x: inf),58.77
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  15x: inf),61.74
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  10x: inf),70.12
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   3x: inf),89.19
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   1x: inf),91.41
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   0x: inf),100.00
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1000x:1500x),0.0005
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 500x:1000x),0.0008
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 100x: 500x),0.0006
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  50x: 100x),0.88
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  20x:  50x),0.41
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  15x:  20x),0.51
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  10x:  15x),0.53
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   3x:  10x),0.27
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   1x:   3x),0.1
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   0x:   1x),0.009
+COVERAGE SUMMARY,,Average chr X coverage over QC coverage region,115.39
+COVERAGE SUMMARY,,Average chr Y coverage over QC coverage region,63.08
+COVERAGE SUMMARY,,Average mitochondrial coverage over QC coverage region,43.7
+COVERAGE SUMMARY,,Average autosomal coverage over QC coverage region,75.62
+COVERAGE SUMMARY,,Median autosomal coverage over QC coverage region,87.09
+COVERAGE SUMMARY,,Mean/Median autosomal coverage ratio over QC coverage region,19.71
+COVERAGE SUMMARY,,Aligned reads,1331523753
+COVERAGE SUMMARY,,Aligned reads in QC coverage region,2839458245,50.18

--- a/data/modules/dragen/pr_1880/sample_3.qc-coverage-region-1_overall_mean_cov.csv
+++ b/data/modules/dragen/pr_1880/sample_3.qc-coverage-region-1_overall_mean_cov.csv
@@ -1,0 +1,1 @@
+Average alignment coverage over C:/path/to/QC_1.bed,0.92

--- a/data/modules/dragen/pr_1880/sample_3.qc-coverage-region-2_coverage_metrics.csv
+++ b/data/modules/dragen/pr_1880/sample_3.qc-coverage-region-2_coverage_metrics.csv
@@ -1,0 +1,33 @@
+COVERAGE SUMMARY,,Aligned bases,2731284946
+COVERAGE SUMMARY,,Aligned bases in QC coverage region,1048846608,97.26
+COVERAGE SUMMARY,,Average alignment coverage over QC coverage region,25.83
+COVERAGE SUMMARY,,Uniformity of coverage (PCT > 0.2*mean) over QC coverage region,61.13
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1500x: inf),0.004
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1000x: inf),0.017
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 500x: inf),0.028
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 100x: inf),0.037
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  50x: inf),4.46
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  20x: inf),55.92
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  15x: inf),60.42
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  10x: inf),74.85
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   3x: inf),84.51
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   1x: inf),90.75
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   0x: inf),100.00
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1000x:1500x),0.0002
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 500x:1000x),0.0001
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 100x: 500x),0.0009
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  50x: 100x),0.67
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  20x:  50x),0.74
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  15x:  20x),0.93
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  10x:  15x),0.48
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   3x:  10x),0.3
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   1x:   3x),0.18
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   0x:   1x),0.0
+COVERAGE SUMMARY,,Average chr X coverage over QC coverage region,56.58
+COVERAGE SUMMARY,,Average chr Y coverage over QC coverage region,64.1
+COVERAGE SUMMARY,,Average mitochondrial coverage over QC coverage region,60.6
+COVERAGE SUMMARY,,Average autosomal coverage over QC coverage region,27.16
+COVERAGE SUMMARY,,Median autosomal coverage over QC coverage region,41.84
+COVERAGE SUMMARY,,Mean/Median autosomal coverage ratio over QC coverage region,2.52
+COVERAGE SUMMARY,,Aligned reads,1541997495
+COVERAGE SUMMARY,,Aligned reads in QC coverage region,2330446439,35.67

--- a/data/modules/dragen/pr_1880/sample_3.qc-coverage-region-2_overall_mean_cov.csv
+++ b/data/modules/dragen/pr_1880/sample_3.qc-coverage-region-2_overall_mean_cov.csv
@@ -1,0 +1,1 @@
+Average alignment coverage over C:/path/to/QC_2.bed,1.0

--- a/data/modules/dragen/pr_1880/sample_3.target_bed_coverage_metrics.csv
+++ b/data/modules/dragen/pr_1880/sample_3.target_bed_coverage_metrics.csv
@@ -1,0 +1,33 @@
+COVERAGE SUMMARY,,Aligned bases,3247750929
+COVERAGE SUMMARY,,Aligned bases in target bed,3115938135,48.24
+COVERAGE SUMMARY,,Average alignment coverage over target bed,14.41
+COVERAGE SUMMARY,,Uniformity of coverage (PCT > 0.2*mean) over target bed,25.15
+COVERAGE SUMMARY,,PCT of target bed with coverage [1500x: inf),0.001
+COVERAGE SUMMARY,,PCT of target bed with coverage [1000x: inf),0.015
+COVERAGE SUMMARY,,PCT of target bed with coverage [ 500x: inf),0.026
+COVERAGE SUMMARY,,PCT of target bed with coverage [ 100x: inf),0.031
+COVERAGE SUMMARY,,PCT of target bed with coverage [  50x: inf),4.93
+COVERAGE SUMMARY,,PCT of target bed with coverage [  20x: inf),54.86
+COVERAGE SUMMARY,,PCT of target bed with coverage [  15x: inf),66.38
+COVERAGE SUMMARY,,PCT of target bed with coverage [  10x: inf),75.63
+COVERAGE SUMMARY,,PCT of target bed with coverage [   3x: inf),88.94
+COVERAGE SUMMARY,,PCT of target bed with coverage [   1x: inf),92.93
+COVERAGE SUMMARY,,PCT of target bed with coverage [   0x: inf),100.00
+COVERAGE SUMMARY,,PCT of target bed with coverage [1000x:1500x),0.0008
+COVERAGE SUMMARY,,PCT of target bed with coverage [ 500x:1000x),0.0007
+COVERAGE SUMMARY,,PCT of target bed with coverage [ 100x: 500x),0.0
+COVERAGE SUMMARY,,PCT of target bed with coverage [  50x: 100x),0.97
+COVERAGE SUMMARY,,PCT of target bed with coverage [  20x:  50x),0.88
+COVERAGE SUMMARY,,PCT of target bed with coverage [  15x:  20x),0.43
+COVERAGE SUMMARY,,PCT of target bed with coverage [  10x:  15x),0.73
+COVERAGE SUMMARY,,PCT of target bed with coverage [   3x:  10x),0.98
+COVERAGE SUMMARY,,PCT of target bed with coverage [   1x:   3x),0.2
+COVERAGE SUMMARY,,PCT of target bed with coverage [   0x:   1x),0.008
+COVERAGE SUMMARY,,Average chr X coverage over target bed,110.41
+COVERAGE SUMMARY,,Average chr Y coverage over target bed,111.2
+COVERAGE SUMMARY,,Average mitochondrial coverage over target bed,23.9
+COVERAGE SUMMARY,,Average autosomal coverage over target bed,27.37
+COVERAGE SUMMARY,,Median autosomal coverage over target bed,36.72
+COVERAGE SUMMARY,,Mean/Median autosomal coverage ratio over target bed,6.26
+COVERAGE SUMMARY,,Aligned reads,3102523571
+COVERAGE SUMMARY,,Aligned reads in target bed,2507116196,2.94

--- a/data/modules/dragen/pr_1880/sample_3.target_bed_overall_mean_cov.csv
+++ b/data/modules/dragen/pr_1880/sample_3.target_bed_overall_mean_cov.csv
@@ -1,0 +1,1 @@
+Average alignment coverage over C:/path/to/very_special_region.bed,0.5

--- a/data/modules/dragen/pr_1880/sample_3.wgs_coverage_metrics.csv
+++ b/data/modules/dragen/pr_1880/sample_3.wgs_coverage_metrics.csv
@@ -1,0 +1,33 @@
+COVERAGE SUMMARY,,Aligned bases,3387031381
+COVERAGE SUMMARY,,Aligned bases in genome,1756984394,61.5
+COVERAGE SUMMARY,,Average alignment coverage over genome,91.43
+COVERAGE SUMMARY,,Uniformity of coverage (PCT > 0.2*mean) over genome,76.81
+COVERAGE SUMMARY,,PCT of genome with coverage [1500x: inf),0.009
+COVERAGE SUMMARY,,PCT of genome with coverage [1000x: inf),0.017
+COVERAGE SUMMARY,,PCT of genome with coverage [ 500x: inf),0.029
+COVERAGE SUMMARY,,PCT of genome with coverage [ 100x: inf),0.033
+COVERAGE SUMMARY,,PCT of genome with coverage [  50x: inf),4.33
+COVERAGE SUMMARY,,PCT of genome with coverage [  20x: inf),59.69
+COVERAGE SUMMARY,,PCT of genome with coverage [  15x: inf),64.7
+COVERAGE SUMMARY,,PCT of genome with coverage [  10x: inf),72.83
+COVERAGE SUMMARY,,PCT of genome with coverage [   3x: inf),85.65
+COVERAGE SUMMARY,,PCT of genome with coverage [   1x: inf),92.55
+COVERAGE SUMMARY,,PCT of genome with coverage [   0x: inf),100.00
+COVERAGE SUMMARY,,PCT of genome with coverage [1000x:1500x),0.0005
+COVERAGE SUMMARY,,PCT of genome with coverage [ 500x:1000x),0.001
+COVERAGE SUMMARY,,PCT of genome with coverage [ 100x: 500x),0.0006
+COVERAGE SUMMARY,,PCT of genome with coverage [  50x: 100x),0.43
+COVERAGE SUMMARY,,PCT of genome with coverage [  20x:  50x),0.77
+COVERAGE SUMMARY,,PCT of genome with coverage [  15x:  20x),1.0
+COVERAGE SUMMARY,,PCT of genome with coverage [  10x:  15x),0.71
+COVERAGE SUMMARY,,PCT of genome with coverage [   3x:  10x),0.21
+COVERAGE SUMMARY,,PCT of genome with coverage [   1x:   3x),0.12
+COVERAGE SUMMARY,,PCT of genome with coverage [   0x:   1x),0.006
+COVERAGE SUMMARY,,Average chr X coverage over genome,20.2
+COVERAGE SUMMARY,,Average chr Y coverage over genome,39.21
+COVERAGE SUMMARY,,Average mitochondrial coverage over genome,17.6
+COVERAGE SUMMARY,,Average autosomal coverage over genome,7.01
+COVERAGE SUMMARY,,Median autosomal coverage over genome,90.14
+COVERAGE SUMMARY,,Mean/Median autosomal coverage ratio over genome,1.52
+COVERAGE SUMMARY,,Aligned reads,1382780652
+COVERAGE SUMMARY,,Aligned reads in genome,1684667130,63.82

--- a/data/modules/dragen/pr_1880/sample_3.wgs_overall_mean_cov.csv
+++ b/data/modules/dragen/pr_1880/sample_3.wgs_overall_mean_cov.csv
@@ -1,0 +1,1 @@
+Average alignment coverage over C:/path/to/Whole_genome_756,0.71

--- a/data/modules/dragen/pr_1880/sample_4.qc-coverage-region-1_coverage_metrics.csv
+++ b/data/modules/dragen/pr_1880/sample_4.qc-coverage-region-1_coverage_metrics.csv
@@ -1,0 +1,33 @@
+COVERAGE SUMMARY,,Aligned bases,1840844033
+COVERAGE SUMMARY,,Aligned bases in QC coverage region,2820425127,14.66
+COVERAGE SUMMARY,,Average alignment coverage over QC coverage region,30.06
+COVERAGE SUMMARY,,Uniformity of coverage (PCT > 0.2*mean) over QC coverage region,2.17
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1500x: inf),0.003
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1000x: inf),0.012
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 500x: inf),0.02
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 100x: inf),0.037
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  50x: inf),4.15
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  20x: inf),55.93
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  15x: inf),67.21
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  10x: inf),73.93
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   3x: inf),88.62
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   1x: inf),96.82
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   0x: inf),100.00
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1000x:1500x),0.0
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 500x:1000x),0.0001
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 100x: 500x),0.0002
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  50x: 100x),0.98
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  20x:  50x),0.58
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  15x:  20x),0.49
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  10x:  15x),0.86
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   3x:  10x),0.79
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   1x:   3x),0.19
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   0x:   1x),0.006
+COVERAGE SUMMARY,,Average chr X coverage over QC coverage region,31.02
+COVERAGE SUMMARY,,Average chr Y coverage over QC coverage region,86.87
+COVERAGE SUMMARY,,Average mitochondrial coverage over QC coverage region,64.3
+COVERAGE SUMMARY,,Average autosomal coverage over QC coverage region,98.95
+COVERAGE SUMMARY,,Median autosomal coverage over QC coverage region,56.36
+COVERAGE SUMMARY,,Mean/Median autosomal coverage ratio over QC coverage region,15.38
+COVERAGE SUMMARY,,Aligned reads,3130587857
+COVERAGE SUMMARY,,Aligned reads in QC coverage region,2191331854,56.0

--- a/data/modules/dragen/pr_1880/sample_4.qc-coverage-region-1_overall_mean_cov.csv
+++ b/data/modules/dragen/pr_1880/sample_4.qc-coverage-region-1_overall_mean_cov.csv
@@ -1,0 +1,1 @@
+Average alignment coverage over C:/path/to/QC_1.bed,0.65

--- a/data/modules/dragen/pr_1880/sample_4.qc-coverage-region-2_coverage_metrics.csv
+++ b/data/modules/dragen/pr_1880/sample_4.qc-coverage-region-2_coverage_metrics.csv
@@ -1,0 +1,33 @@
+COVERAGE SUMMARY,,Aligned bases,1935243601
+COVERAGE SUMMARY,,Aligned bases in QC coverage region,1325926973,42.73
+COVERAGE SUMMARY,,Average alignment coverage over QC coverage region,77.3
+COVERAGE SUMMARY,,Uniformity of coverage (PCT > 0.2*mean) over QC coverage region,49.2
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1500x: inf),0.01
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1000x: inf),0.016
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 500x: inf),0.029
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 100x: inf),0.04
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  50x: inf),4.75
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  20x: inf),54.22
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  15x: inf),66.92
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  10x: inf),70.08
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   3x: inf),80.37
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   1x: inf),91.14
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   0x: inf),100.00
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1000x:1500x),0.0001
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 500x:1000x),0.0008
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 100x: 500x),0.0004
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  50x: 100x),0.79
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  20x:  50x),0.92
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  15x:  20x),0.5
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  10x:  15x),0.55
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   3x:  10x),0.63
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   1x:   3x),0.1
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   0x:   1x),0.005
+COVERAGE SUMMARY,,Average chr X coverage over QC coverage region,55.94
+COVERAGE SUMMARY,,Average chr Y coverage over QC coverage region,63.13
+COVERAGE SUMMARY,,Average mitochondrial coverage over QC coverage region,16.6
+COVERAGE SUMMARY,,Average autosomal coverage over QC coverage region,80.15
+COVERAGE SUMMARY,,Median autosomal coverage over QC coverage region,10.31
+COVERAGE SUMMARY,,Mean/Median autosomal coverage ratio over QC coverage region,85.71
+COVERAGE SUMMARY,,Aligned reads,3811282788
+COVERAGE SUMMARY,,Aligned reads in QC coverage region,2230467531,23.0

--- a/data/modules/dragen/pr_1880/sample_4.qc-coverage-region-2_overall_mean_cov.csv
+++ b/data/modules/dragen/pr_1880/sample_4.qc-coverage-region-2_overall_mean_cov.csv
@@ -1,0 +1,1 @@
+Average alignment coverage over C:/path/to/QC_2.bed,0.45

--- a/data/modules/dragen/pr_1880/sample_4.target_bed_coverage_metrics.csv
+++ b/data/modules/dragen/pr_1880/sample_4.target_bed_coverage_metrics.csv
@@ -1,0 +1,33 @@
+COVERAGE SUMMARY,,Aligned bases,1120494144
+COVERAGE SUMMARY,,Aligned bases in target bed,2374953975,64.76
+COVERAGE SUMMARY,,Average alignment coverage over target bed,97.81
+COVERAGE SUMMARY,,Uniformity of coverage (PCT > 0.2*mean) over target bed,63.26
+COVERAGE SUMMARY,,PCT of target bed with coverage [1500x: inf),0.006
+COVERAGE SUMMARY,,PCT of target bed with coverage [1000x: inf),0.015
+COVERAGE SUMMARY,,PCT of target bed with coverage [ 500x: inf),0.027
+COVERAGE SUMMARY,,PCT of target bed with coverage [ 100x: inf),0.035
+COVERAGE SUMMARY,,PCT of target bed with coverage [  50x: inf),4.24
+COVERAGE SUMMARY,,PCT of target bed with coverage [  20x: inf),56.56
+COVERAGE SUMMARY,,PCT of target bed with coverage [  15x: inf),65.88
+COVERAGE SUMMARY,,PCT of target bed with coverage [  10x: inf),73.36
+COVERAGE SUMMARY,,PCT of target bed with coverage [   3x: inf),86.42
+COVERAGE SUMMARY,,PCT of target bed with coverage [   1x: inf),95.96
+COVERAGE SUMMARY,,PCT of target bed with coverage [   0x: inf),100.00
+COVERAGE SUMMARY,,PCT of target bed with coverage [1000x:1500x),0.0004
+COVERAGE SUMMARY,,PCT of target bed with coverage [ 500x:1000x),0.0004
+COVERAGE SUMMARY,,PCT of target bed with coverage [ 100x: 500x),0.0003
+COVERAGE SUMMARY,,PCT of target bed with coverage [  50x: 100x),0.93
+COVERAGE SUMMARY,,PCT of target bed with coverage [  20x:  50x),0.97
+COVERAGE SUMMARY,,PCT of target bed with coverage [  15x:  20x),0.88
+COVERAGE SUMMARY,,PCT of target bed with coverage [  10x:  15x),0.48
+COVERAGE SUMMARY,,PCT of target bed with coverage [   3x:  10x),0.23
+COVERAGE SUMMARY,,PCT of target bed with coverage [   1x:   3x),0.13
+COVERAGE SUMMARY,,PCT of target bed with coverage [   0x:   1x),0.009
+COVERAGE SUMMARY,,Average chr X coverage over target bed,62.83
+COVERAGE SUMMARY,,Average chr Y coverage over target bed,26.73
+COVERAGE SUMMARY,,Average mitochondrial coverage over target bed,55.9
+COVERAGE SUMMARY,,Average autosomal coverage over target bed,97.92
+COVERAGE SUMMARY,,Median autosomal coverage over target bed,43.26
+COVERAGE SUMMARY,,Mean/Median autosomal coverage ratio over target bed,80.8
+COVERAGE SUMMARY,,Aligned reads,1147634916
+COVERAGE SUMMARY,,Aligned reads in target bed,2874627826,26.41

--- a/data/modules/dragen/pr_1880/sample_4.target_bed_overall_mean_cov.csv
+++ b/data/modules/dragen/pr_1880/sample_4.target_bed_overall_mean_cov.csv
@@ -1,0 +1,1 @@
+Average alignment coverage over C:/path/to/very_special_region.bed,0.61

--- a/data/modules/dragen/pr_1880/sample_4.wgs_coverage_metrics.csv
+++ b/data/modules/dragen/pr_1880/sample_4.wgs_coverage_metrics.csv
@@ -1,0 +1,33 @@
+COVERAGE SUMMARY,,Aligned bases,2131000340
+COVERAGE SUMMARY,,Aligned bases in genome,3678854886,92.92
+COVERAGE SUMMARY,,Average alignment coverage over genome,7.16
+COVERAGE SUMMARY,,Uniformity of coverage (PCT > 0.2*mean) over genome,57.89
+COVERAGE SUMMARY,,PCT of genome with coverage [1500x: inf),0.007
+COVERAGE SUMMARY,,PCT of genome with coverage [1000x: inf),0.014
+COVERAGE SUMMARY,,PCT of genome with coverage [ 500x: inf),0.021
+COVERAGE SUMMARY,,PCT of genome with coverage [ 100x: inf),0.039
+COVERAGE SUMMARY,,PCT of genome with coverage [  50x: inf),4.14
+COVERAGE SUMMARY,,PCT of genome with coverage [  20x: inf),52.84
+COVERAGE SUMMARY,,PCT of genome with coverage [  15x: inf),69.59
+COVERAGE SUMMARY,,PCT of genome with coverage [  10x: inf),74.28
+COVERAGE SUMMARY,,PCT of genome with coverage [   3x: inf),88.87
+COVERAGE SUMMARY,,PCT of genome with coverage [   1x: inf),91.21
+COVERAGE SUMMARY,,PCT of genome with coverage [   0x: inf),100.00
+COVERAGE SUMMARY,,PCT of genome with coverage [1000x:1500x),0.0002
+COVERAGE SUMMARY,,PCT of genome with coverage [ 500x:1000x),0.0008
+COVERAGE SUMMARY,,PCT of genome with coverage [ 100x: 500x),0.0003
+COVERAGE SUMMARY,,PCT of genome with coverage [  50x: 100x),0.89
+COVERAGE SUMMARY,,PCT of genome with coverage [  20x:  50x),0.75
+COVERAGE SUMMARY,,PCT of genome with coverage [  15x:  20x),0.9
+COVERAGE SUMMARY,,PCT of genome with coverage [  10x:  15x),1.0
+COVERAGE SUMMARY,,PCT of genome with coverage [   3x:  10x),0.87
+COVERAGE SUMMARY,,PCT of genome with coverage [   1x:   3x),0.12
+COVERAGE SUMMARY,,PCT of genome with coverage [   0x:   1x),0.006
+COVERAGE SUMMARY,,Average chr X coverage over genome,76.46
+COVERAGE SUMMARY,,Average chr Y coverage over genome,38.33
+COVERAGE SUMMARY,,Average mitochondrial coverage over genome,69.6
+COVERAGE SUMMARY,,Average autosomal coverage over genome,52.29
+COVERAGE SUMMARY,,Median autosomal coverage over genome,30.88
+COVERAGE SUMMARY,,Mean/Median autosomal coverage ratio over genome,32.4
+COVERAGE SUMMARY,,Aligned reads,3124275237
+COVERAGE SUMMARY,,Aligned reads in genome,3879570449,94.41

--- a/data/modules/dragen/pr_1880/sample_4.wgs_overall_mean_cov.csv
+++ b/data/modules/dragen/pr_1880/sample_4.wgs_overall_mean_cov.csv
@@ -1,0 +1,1 @@
+Average alignment coverage over C:/path/to/Whole_genome_756,0.8

--- a/data/modules/dragen/pr_1880/sample_5.qc-coverage-region-1_coverage_metrics.csv
+++ b/data/modules/dragen/pr_1880/sample_5.qc-coverage-region-1_coverage_metrics.csv
@@ -1,0 +1,33 @@
+COVERAGE SUMMARY,,Aligned bases,2895936709
+COVERAGE SUMMARY,,Aligned bases in QC coverage region,1513426388,33.71
+COVERAGE SUMMARY,,Average alignment coverage over QC coverage region,88.67
+COVERAGE SUMMARY,,Uniformity of coverage (PCT > 0.2*mean) over QC coverage region,49.44
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1500x: inf),0.008
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1000x: inf),0.015
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 500x: inf),0.028
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 100x: inf),0.033
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  50x: inf),4.92
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  20x: inf),50.73
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  15x: inf),68.49
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  10x: inf),79.62
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   3x: inf),80.4
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   1x: inf),97.48
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   0x: inf),100.00
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1000x:1500x),0.0001
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 500x:1000x),0.0007
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 100x: 500x),0.001
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  50x: 100x),0.59
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  20x:  50x),0.44
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  15x:  20x),0.98
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  10x:  15x),0.88
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   3x:  10x),0.78
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   1x:   3x),0.19
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   0x:   1x),0.007
+COVERAGE SUMMARY,,Average chr X coverage over QC coverage region,71.66
+COVERAGE SUMMARY,,Average chr Y coverage over QC coverage region,109.54
+COVERAGE SUMMARY,,Average mitochondrial coverage over QC coverage region,22.4
+COVERAGE SUMMARY,,Average autosomal coverage over QC coverage region,7.83
+COVERAGE SUMMARY,,Median autosomal coverage over QC coverage region,75.75
+COVERAGE SUMMARY,,Mean/Median autosomal coverage ratio over QC coverage region,32.98
+COVERAGE SUMMARY,,Aligned reads,2876500136
+COVERAGE SUMMARY,,Aligned reads in QC coverage region,2335705412,79.87

--- a/data/modules/dragen/pr_1880/sample_5.qc-coverage-region-1_overall_mean_cov.csv
+++ b/data/modules/dragen/pr_1880/sample_5.qc-coverage-region-1_overall_mean_cov.csv
@@ -1,0 +1,1 @@
+Average alignment coverage over C:/path/to/QC_1.bed,0.75

--- a/data/modules/dragen/pr_1880/sample_5.qc-coverage-region-2_coverage_metrics.csv
+++ b/data/modules/dragen/pr_1880/sample_5.qc-coverage-region-2_coverage_metrics.csv
@@ -1,0 +1,33 @@
+COVERAGE SUMMARY,,Aligned bases,2120365484
+COVERAGE SUMMARY,,Aligned bases in QC coverage region,3576898528,81.4
+COVERAGE SUMMARY,,Average alignment coverage over QC coverage region,11.28
+COVERAGE SUMMARY,,Uniformity of coverage (PCT > 0.2*mean) over QC coverage region,39.59
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1500x: inf),0.009
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1000x: inf),0.016
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 500x: inf),0.02
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 100x: inf),0.035
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  50x: inf),4.46
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  20x: inf),52.11
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  15x: inf),64.43
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  10x: inf),77.03
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   3x: inf),89.11
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   1x: inf),91.76
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   0x: inf),100.00
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1000x:1500x),0.001
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 500x:1000x),0.0008
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 100x: 500x),0.0001
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  50x: 100x),0.54
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  20x:  50x),0.57
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  15x:  20x),0.48
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  10x:  15x),0.54
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   3x:  10x),0.47
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   1x:   3x),0.1
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   0x:   1x),0.007
+COVERAGE SUMMARY,,Average chr X coverage over QC coverage region,117.63
+COVERAGE SUMMARY,,Average chr Y coverage over QC coverage region,45.37
+COVERAGE SUMMARY,,Average mitochondrial coverage over QC coverage region,35.8
+COVERAGE SUMMARY,,Average autosomal coverage over QC coverage region,71.3
+COVERAGE SUMMARY,,Median autosomal coverage over QC coverage region,19.33
+COVERAGE SUMMARY,,Mean/Median autosomal coverage ratio over QC coverage region,55.83
+COVERAGE SUMMARY,,Aligned reads,1374835381
+COVERAGE SUMMARY,,Aligned reads in QC coverage region,3687044229,40.19

--- a/data/modules/dragen/pr_1880/sample_5.qc-coverage-region-2_overall_mean_cov.csv
+++ b/data/modules/dragen/pr_1880/sample_5.qc-coverage-region-2_overall_mean_cov.csv
@@ -1,0 +1,1 @@
+Average alignment coverage over C:/path/to/QC_2.bed,0.62

--- a/data/modules/dragen/pr_1880/sample_5.target_bed_coverage_metrics.csv
+++ b/data/modules/dragen/pr_1880/sample_5.target_bed_coverage_metrics.csv
@@ -1,0 +1,33 @@
+COVERAGE SUMMARY,,Aligned bases,2463148475
+COVERAGE SUMMARY,,Aligned bases in target bed,2579878897,72.68
+COVERAGE SUMMARY,,Average alignment coverage over target bed,31.63
+COVERAGE SUMMARY,,Uniformity of coverage (PCT > 0.2*mean) over target bed,12.45
+COVERAGE SUMMARY,,PCT of target bed with coverage [1500x: inf),0.01
+COVERAGE SUMMARY,,PCT of target bed with coverage [1000x: inf),0.013
+COVERAGE SUMMARY,,PCT of target bed with coverage [ 500x: inf),0.03
+COVERAGE SUMMARY,,PCT of target bed with coverage [ 100x: inf),0.038
+COVERAGE SUMMARY,,PCT of target bed with coverage [  50x: inf),4.12
+COVERAGE SUMMARY,,PCT of target bed with coverage [  20x: inf),54.9
+COVERAGE SUMMARY,,PCT of target bed with coverage [  15x: inf),63.2
+COVERAGE SUMMARY,,PCT of target bed with coverage [  10x: inf),71.33
+COVERAGE SUMMARY,,PCT of target bed with coverage [   3x: inf),80.27
+COVERAGE SUMMARY,,PCT of target bed with coverage [   1x: inf),90.53
+COVERAGE SUMMARY,,PCT of target bed with coverage [   0x: inf),100.00
+COVERAGE SUMMARY,,PCT of target bed with coverage [1000x:1500x),0.0007
+COVERAGE SUMMARY,,PCT of target bed with coverage [ 500x:1000x),0.0004
+COVERAGE SUMMARY,,PCT of target bed with coverage [ 100x: 500x),0.0004
+COVERAGE SUMMARY,,PCT of target bed with coverage [  50x: 100x),0.81
+COVERAGE SUMMARY,,PCT of target bed with coverage [  20x:  50x),0.94
+COVERAGE SUMMARY,,PCT of target bed with coverage [  15x:  20x),0.56
+COVERAGE SUMMARY,,PCT of target bed with coverage [  10x:  15x),0.41
+COVERAGE SUMMARY,,PCT of target bed with coverage [   3x:  10x),0.98
+COVERAGE SUMMARY,,PCT of target bed with coverage [   1x:   3x),0.13
+COVERAGE SUMMARY,,PCT of target bed with coverage [   0x:   1x),0.001
+COVERAGE SUMMARY,,Average chr X coverage over target bed,53.77
+COVERAGE SUMMARY,,Average chr Y coverage over target bed,114.74
+COVERAGE SUMMARY,,Average mitochondrial coverage over target bed,22.9
+COVERAGE SUMMARY,,Average autosomal coverage over target bed,1.97
+COVERAGE SUMMARY,,Median autosomal coverage over target bed,17.43
+COVERAGE SUMMARY,,Mean/Median autosomal coverage ratio over target bed,36.38
+COVERAGE SUMMARY,,Aligned reads,3804545227
+COVERAGE SUMMARY,,Aligned reads in target bed,1443568952,69.1

--- a/data/modules/dragen/pr_1880/sample_5.target_bed_overall_mean_cov.csv
+++ b/data/modules/dragen/pr_1880/sample_5.target_bed_overall_mean_cov.csv
@@ -1,0 +1,1 @@
+Average alignment coverage over C:/path/to/very_special_region.bed,0.58

--- a/data/modules/dragen/pr_1880/sample_5.wgs_coverage_metrics.csv
+++ b/data/modules/dragen/pr_1880/sample_5.wgs_coverage_metrics.csv
@@ -1,0 +1,33 @@
+COVERAGE SUMMARY,,Aligned bases,3625452654
+COVERAGE SUMMARY,,Aligned bases in genome,3727422102,11.6
+COVERAGE SUMMARY,,Average alignment coverage over genome,54.55
+COVERAGE SUMMARY,,Uniformity of coverage (PCT > 0.2*mean) over genome,51.55
+COVERAGE SUMMARY,,PCT of genome with coverage [1500x: inf),0.0
+COVERAGE SUMMARY,,PCT of genome with coverage [1000x: inf),0.012
+COVERAGE SUMMARY,,PCT of genome with coverage [ 500x: inf),0.027
+COVERAGE SUMMARY,,PCT of genome with coverage [ 100x: inf),0.031
+COVERAGE SUMMARY,,PCT of genome with coverage [  50x: inf),4.64
+COVERAGE SUMMARY,,PCT of genome with coverage [  20x: inf),50.79
+COVERAGE SUMMARY,,PCT of genome with coverage [  15x: inf),61.77
+COVERAGE SUMMARY,,PCT of genome with coverage [  10x: inf),72.24
+COVERAGE SUMMARY,,PCT of genome with coverage [   3x: inf),88.28
+COVERAGE SUMMARY,,PCT of genome with coverage [   1x: inf),93.3
+COVERAGE SUMMARY,,PCT of genome with coverage [   0x: inf),100.00
+COVERAGE SUMMARY,,PCT of genome with coverage [1000x:1500x),0.0
+COVERAGE SUMMARY,,PCT of genome with coverage [ 500x:1000x),0.0006
+COVERAGE SUMMARY,,PCT of genome with coverage [ 100x: 500x),0.0
+COVERAGE SUMMARY,,PCT of genome with coverage [  50x: 100x),0.63
+COVERAGE SUMMARY,,PCT of genome with coverage [  20x:  50x),0.88
+COVERAGE SUMMARY,,PCT of genome with coverage [  15x:  20x),0.4
+COVERAGE SUMMARY,,PCT of genome with coverage [  10x:  15x),1.0
+COVERAGE SUMMARY,,PCT of genome with coverage [   3x:  10x),0.56
+COVERAGE SUMMARY,,PCT of genome with coverage [   1x:   3x),0.1
+COVERAGE SUMMARY,,PCT of genome with coverage [   0x:   1x),0.004
+COVERAGE SUMMARY,,Average chr X coverage over genome,111.8
+COVERAGE SUMMARY,,Average chr Y coverage over genome,22.66
+COVERAGE SUMMARY,,Average mitochondrial coverage over genome,3.4
+COVERAGE SUMMARY,,Average autosomal coverage over genome,76.56
+COVERAGE SUMMARY,,Median autosomal coverage over genome,78.61
+COVERAGE SUMMARY,,Mean/Median autosomal coverage ratio over genome,0.43
+COVERAGE SUMMARY,,Aligned reads,3583077781
+COVERAGE SUMMARY,,Aligned reads in genome,1243801482,71.15

--- a/data/modules/dragen/pr_1880/sample_5.wgs_overall_mean_cov.csv
+++ b/data/modules/dragen/pr_1880/sample_5.wgs_overall_mean_cov.csv
@@ -1,0 +1,1 @@
+Average alignment coverage over C:/path/to/Whole_genome_756,0.86

--- a/data/modules/dragen/pr_1880/sample_6.qc-coverage-region-1_coverage_metrics.csv
+++ b/data/modules/dragen/pr_1880/sample_6.qc-coverage-region-1_coverage_metrics.csv
@@ -1,0 +1,33 @@
+COVERAGE SUMMARY,,Aligned bases,2221590549
+COVERAGE SUMMARY,,Aligned bases in QC coverage region,3006058312,55.7
+COVERAGE SUMMARY,,Average alignment coverage over QC coverage region,99.6
+COVERAGE SUMMARY,,Uniformity of coverage (PCT > 0.2*mean) over QC coverage region,33.87
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1500x: inf),0.007
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1000x: inf),0.02
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 500x: inf),0.027
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 100x: inf),0.03
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  50x: inf),4.22
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  20x: inf),51.74
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  15x: inf),63.01
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  10x: inf),71.97
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   3x: inf),81.31
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   1x: inf),95.31
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   0x: inf),100.00
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1000x:1500x),0.0008
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 500x:1000x),0.0008
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 100x: 500x),0.001
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  50x: 100x),0.46
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  20x:  50x),0.73
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  15x:  20x),0.65
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  10x:  15x),0.56
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   3x:  10x),0.42
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   1x:   3x),0.15
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   0x:   1x),0.0
+COVERAGE SUMMARY,,Average chr X coverage over QC coverage region,26.09
+COVERAGE SUMMARY,,Average chr Y coverage over QC coverage region,107.08
+COVERAGE SUMMARY,,Average mitochondrial coverage over QC coverage region,33.4
+COVERAGE SUMMARY,,Average autosomal coverage over QC coverage region,57.1
+COVERAGE SUMMARY,,Median autosomal coverage over QC coverage region,91.7
+COVERAGE SUMMARY,,Mean/Median autosomal coverage ratio over QC coverage region,48.44
+COVERAGE SUMMARY,,Aligned reads,2064176825
+COVERAGE SUMMARY,,Aligned reads in QC coverage region,3421230167,83.95

--- a/data/modules/dragen/pr_1880/sample_6.qc-coverage-region-1_overall_mean_cov.csv
+++ b/data/modules/dragen/pr_1880/sample_6.qc-coverage-region-1_overall_mean_cov.csv
@@ -1,0 +1,1 @@
+Average alignment coverage over C:/path/to/QC_1.bed,0.62

--- a/data/modules/dragen/pr_1880/sample_6.qc-coverage-region-2_coverage_metrics.csv
+++ b/data/modules/dragen/pr_1880/sample_6.qc-coverage-region-2_coverage_metrics.csv
@@ -1,0 +1,33 @@
+COVERAGE SUMMARY,,Aligned bases,1337918435
+COVERAGE SUMMARY,,Aligned bases in QC coverage region,3266733839,67.59
+COVERAGE SUMMARY,,Average alignment coverage over QC coverage region,80.58
+COVERAGE SUMMARY,,Uniformity of coverage (PCT > 0.2*mean) over QC coverage region,32.13
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1500x: inf),0.007
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1000x: inf),0.016
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 500x: inf),0.021
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 100x: inf),0.035
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  50x: inf),4.3
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  20x: inf),59.88
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  15x: inf),60.02
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  10x: inf),72.97
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   3x: inf),80.8
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   1x: inf),92.83
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   0x: inf),100.00
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1000x:1500x),0.0005
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 500x:1000x),0.0
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 100x: 500x),0.0
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  50x: 100x),0.73
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  20x:  50x),0.56
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  15x:  20x),0.85
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  10x:  15x),0.54
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   3x:  10x),0.28
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   1x:   3x),0.16
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   0x:   1x),0.006
+COVERAGE SUMMARY,,Average chr X coverage over QC coverage region,98.07
+COVERAGE SUMMARY,,Average chr Y coverage over QC coverage region,29.79
+COVERAGE SUMMARY,,Average mitochondrial coverage over QC coverage region,11.0
+COVERAGE SUMMARY,,Average autosomal coverage over QC coverage region,29.18
+COVERAGE SUMMARY,,Median autosomal coverage over QC coverage region,15.47
+COVERAGE SUMMARY,,Mean/Median autosomal coverage ratio over QC coverage region,81.78
+COVERAGE SUMMARY,,Aligned reads,3626644985
+COVERAGE SUMMARY,,Aligned reads in QC coverage region,3843935674,54.87

--- a/data/modules/dragen/pr_1880/sample_6.qc-coverage-region-2_overall_mean_cov.csv
+++ b/data/modules/dragen/pr_1880/sample_6.qc-coverage-region-2_overall_mean_cov.csv
@@ -1,0 +1,1 @@
+Average alignment coverage over C:/path/to/QC_2.bed,0.74

--- a/data/modules/dragen/pr_1880/sample_6.target_bed_coverage_metrics.csv
+++ b/data/modules/dragen/pr_1880/sample_6.target_bed_coverage_metrics.csv
@@ -1,0 +1,33 @@
+COVERAGE SUMMARY,,Aligned bases,1780099122
+COVERAGE SUMMARY,,Aligned bases in target bed,3072281083,9.09
+COVERAGE SUMMARY,,Average alignment coverage over target bed,10.38
+COVERAGE SUMMARY,,Uniformity of coverage (PCT > 0.2*mean) over target bed,54.36
+COVERAGE SUMMARY,,PCT of target bed with coverage [1500x: inf),0.005
+COVERAGE SUMMARY,,PCT of target bed with coverage [1000x: inf),0.01
+COVERAGE SUMMARY,,PCT of target bed with coverage [ 500x: inf),0.024
+COVERAGE SUMMARY,,PCT of target bed with coverage [ 100x: inf),0.038
+COVERAGE SUMMARY,,PCT of target bed with coverage [  50x: inf),4.41
+COVERAGE SUMMARY,,PCT of target bed with coverage [  20x: inf),57.99
+COVERAGE SUMMARY,,PCT of target bed with coverage [  15x: inf),63.01
+COVERAGE SUMMARY,,PCT of target bed with coverage [  10x: inf),76.13
+COVERAGE SUMMARY,,PCT of target bed with coverage [   3x: inf),87.67
+COVERAGE SUMMARY,,PCT of target bed with coverage [   1x: inf),97.85
+COVERAGE SUMMARY,,PCT of target bed with coverage [   0x: inf),100.00
+COVERAGE SUMMARY,,PCT of target bed with coverage [1000x:1500x),0.0003
+COVERAGE SUMMARY,,PCT of target bed with coverage [ 500x:1000x),0.0006
+COVERAGE SUMMARY,,PCT of target bed with coverage [ 100x: 500x),0.001
+COVERAGE SUMMARY,,PCT of target bed with coverage [  50x: 100x),0.75
+COVERAGE SUMMARY,,PCT of target bed with coverage [  20x:  50x),0.95
+COVERAGE SUMMARY,,PCT of target bed with coverage [  15x:  20x),0.94
+COVERAGE SUMMARY,,PCT of target bed with coverage [  10x:  15x),0.74
+COVERAGE SUMMARY,,PCT of target bed with coverage [   3x:  10x),0.23
+COVERAGE SUMMARY,,PCT of target bed with coverage [   1x:   3x),0.13
+COVERAGE SUMMARY,,PCT of target bed with coverage [   0x:   1x),0.002
+COVERAGE SUMMARY,,Average chr X coverage over target bed,45.93
+COVERAGE SUMMARY,,Average chr Y coverage over target bed,89.98
+COVERAGE SUMMARY,,Average mitochondrial coverage over target bed,26.7
+COVERAGE SUMMARY,,Average autosomal coverage over target bed,96.38
+COVERAGE SUMMARY,,Median autosomal coverage over target bed,56.21
+COVERAGE SUMMARY,,Mean/Median autosomal coverage ratio over target bed,67.65
+COVERAGE SUMMARY,,Aligned reads,3121923092
+COVERAGE SUMMARY,,Aligned reads in target bed,3702550124,66.1

--- a/data/modules/dragen/pr_1880/sample_6.target_bed_overall_mean_cov.csv
+++ b/data/modules/dragen/pr_1880/sample_6.target_bed_overall_mean_cov.csv
@@ -1,0 +1,1 @@
+Average alignment coverage over C:/path/to/very_special_region.bed,0.65

--- a/data/modules/dragen/pr_1880/sample_6.wgs_coverage_metrics.csv
+++ b/data/modules/dragen/pr_1880/sample_6.wgs_coverage_metrics.csv
@@ -1,0 +1,33 @@
+COVERAGE SUMMARY,,Aligned bases,3108773425
+COVERAGE SUMMARY,,Aligned bases in genome,1688770242,81.02
+COVERAGE SUMMARY,,Average alignment coverage over genome,36.37
+COVERAGE SUMMARY,,Uniformity of coverage (PCT > 0.2*mean) over genome,84.08
+COVERAGE SUMMARY,,PCT of genome with coverage [1500x: inf),0.005
+COVERAGE SUMMARY,,PCT of genome with coverage [1000x: inf),0.015
+COVERAGE SUMMARY,,PCT of genome with coverage [ 500x: inf),0.03
+COVERAGE SUMMARY,,PCT of genome with coverage [ 100x: inf),0.039
+COVERAGE SUMMARY,,PCT of genome with coverage [  50x: inf),4.18
+COVERAGE SUMMARY,,PCT of genome with coverage [  20x: inf),54.96
+COVERAGE SUMMARY,,PCT of genome with coverage [  15x: inf),65.51
+COVERAGE SUMMARY,,PCT of genome with coverage [  10x: inf),76.54
+COVERAGE SUMMARY,,PCT of genome with coverage [   3x: inf),86.87
+COVERAGE SUMMARY,,PCT of genome with coverage [   1x: inf),95.85
+COVERAGE SUMMARY,,PCT of genome with coverage [   0x: inf),100.00
+COVERAGE SUMMARY,,PCT of genome with coverage [1000x:1500x),0.0003
+COVERAGE SUMMARY,,PCT of genome with coverage [ 500x:1000x),0.001
+COVERAGE SUMMARY,,PCT of genome with coverage [ 100x: 500x),0.0002
+COVERAGE SUMMARY,,PCT of genome with coverage [  50x: 100x),0.5
+COVERAGE SUMMARY,,PCT of genome with coverage [  20x:  50x),0.67
+COVERAGE SUMMARY,,PCT of genome with coverage [  15x:  20x),0.51
+COVERAGE SUMMARY,,PCT of genome with coverage [  10x:  15x),0.82
+COVERAGE SUMMARY,,PCT of genome with coverage [   3x:  10x),0.86
+COVERAGE SUMMARY,,PCT of genome with coverage [   1x:   3x),0.1
+COVERAGE SUMMARY,,PCT of genome with coverage [   0x:   1x),0.007
+COVERAGE SUMMARY,,Average chr X coverage over genome,50.11
+COVERAGE SUMMARY,,Average chr Y coverage over genome,115.08
+COVERAGE SUMMARY,,Average mitochondrial coverage over genome,77.7
+COVERAGE SUMMARY,,Average autosomal coverage over genome,17.39
+COVERAGE SUMMARY,,Median autosomal coverage over genome,64.93
+COVERAGE SUMMARY,,Mean/Median autosomal coverage ratio over genome,20.41
+COVERAGE SUMMARY,,Aligned reads,1715737627
+COVERAGE SUMMARY,,Aligned reads in genome,1554724521,77.67

--- a/data/modules/dragen/pr_1880/sample_6.wgs_overall_mean_cov.csv
+++ b/data/modules/dragen/pr_1880/sample_6.wgs_overall_mean_cov.csv
@@ -1,0 +1,1 @@
+Average alignment coverage over C:/path/to/Whole_genome_756,0.98

--- a/data/modules/dragen/pr_1880/sample_7.qc-coverage-region-1_coverage_metrics.csv
+++ b/data/modules/dragen/pr_1880/sample_7.qc-coverage-region-1_coverage_metrics.csv
@@ -1,0 +1,33 @@
+COVERAGE SUMMARY,,Aligned bases,1516468597
+COVERAGE SUMMARY,,Aligned bases in QC coverage region,1777928536,35.88
+COVERAGE SUMMARY,,Average alignment coverage over QC coverage region,87.88
+COVERAGE SUMMARY,,Uniformity of coverage (PCT > 0.2*mean) over QC coverage region,5.44
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1500x: inf),0.003
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1000x: inf),0.018
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 500x: inf),0.026
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 100x: inf),0.04
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  50x: inf),4.11
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  20x: inf),59.63
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  15x: inf),60.33
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  10x: inf),73.38
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   3x: inf),80.36
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   1x: inf),94.05
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   0x: inf),100.00
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1000x:1500x),0.0
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 500x:1000x),0.0002
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 100x: 500x),0.0002
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  50x: 100x),0.54
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  20x:  50x),0.99
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  15x:  20x),0.76
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  10x:  15x),0.44
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   3x:  10x),0.25
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   1x:   3x),0.16
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   0x:   1x),0.006
+COVERAGE SUMMARY,,Average chr X coverage over QC coverage region,82.94
+COVERAGE SUMMARY,,Average chr Y coverage over QC coverage region,85.64
+COVERAGE SUMMARY,,Average mitochondrial coverage over QC coverage region,92.4
+COVERAGE SUMMARY,,Average autosomal coverage over QC coverage region,49.87
+COVERAGE SUMMARY,,Median autosomal coverage over QC coverage region,60.72
+COVERAGE SUMMARY,,Mean/Median autosomal coverage ratio over QC coverage region,98.46
+COVERAGE SUMMARY,,Aligned reads,1815401364
+COVERAGE SUMMARY,,Aligned reads in QC coverage region,3771432906,61.53

--- a/data/modules/dragen/pr_1880/sample_7.qc-coverage-region-1_overall_mean_cov.csv
+++ b/data/modules/dragen/pr_1880/sample_7.qc-coverage-region-1_overall_mean_cov.csv
@@ -1,0 +1,1 @@
+Average alignment coverage over C:/path/to/QC_1.bed,0.72

--- a/data/modules/dragen/pr_1880/sample_7.qc-coverage-region-2_coverage_metrics.csv
+++ b/data/modules/dragen/pr_1880/sample_7.qc-coverage-region-2_coverage_metrics.csv
@@ -1,0 +1,33 @@
+COVERAGE SUMMARY,,Aligned bases,2068772088
+COVERAGE SUMMARY,,Aligned bases in QC coverage region,3958400920,96.65
+COVERAGE SUMMARY,,Average alignment coverage over QC coverage region,58.15
+COVERAGE SUMMARY,,Uniformity of coverage (PCT > 0.2*mean) over QC coverage region,48.97
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1500x: inf),0.0
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1000x: inf),0.011
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 500x: inf),0.025
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 100x: inf),0.031
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  50x: inf),4.3
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  20x: inf),54.57
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  15x: inf),63.37
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  10x: inf),74.96
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   3x: inf),81.26
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   1x: inf),96.0
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   0x: inf),100.00
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1000x:1500x),0.0005
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 500x:1000x),0.0008
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 100x: 500x),0.001
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  50x: 100x),0.92
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  20x:  50x),0.51
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  15x:  20x),0.64
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  10x:  15x),0.56
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   3x:  10x),0.37
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   1x:   3x),0.19
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   0x:   1x),0.01
+COVERAGE SUMMARY,,Average chr X coverage over QC coverage region,64.44
+COVERAGE SUMMARY,,Average chr Y coverage over QC coverage region,86.0
+COVERAGE SUMMARY,,Average mitochondrial coverage over QC coverage region,4.5
+COVERAGE SUMMARY,,Average autosomal coverage over QC coverage region,69.22
+COVERAGE SUMMARY,,Median autosomal coverage over QC coverage region,4.65
+COVERAGE SUMMARY,,Mean/Median autosomal coverage ratio over QC coverage region,79.75
+COVERAGE SUMMARY,,Aligned reads,1599258748
+COVERAGE SUMMARY,,Aligned reads in QC coverage region,1300568318,21.19

--- a/data/modules/dragen/pr_1880/sample_7.qc-coverage-region-2_overall_mean_cov.csv
+++ b/data/modules/dragen/pr_1880/sample_7.qc-coverage-region-2_overall_mean_cov.csv
@@ -1,0 +1,1 @@
+Average alignment coverage over C:/path/to/QC_2.bed,0.0

--- a/data/modules/dragen/pr_1880/sample_7.target_bed_coverage_metrics.csv
+++ b/data/modules/dragen/pr_1880/sample_7.target_bed_coverage_metrics.csv
@@ -1,0 +1,33 @@
+COVERAGE SUMMARY,,Aligned bases,3767790914
+COVERAGE SUMMARY,,Aligned bases in target bed,3680165847,40.04
+COVERAGE SUMMARY,,Average alignment coverage over target bed,58.17
+COVERAGE SUMMARY,,Uniformity of coverage (PCT > 0.2*mean) over target bed,51.65
+COVERAGE SUMMARY,,PCT of target bed with coverage [1500x: inf),0.0
+COVERAGE SUMMARY,,PCT of target bed with coverage [1000x: inf),0.02
+COVERAGE SUMMARY,,PCT of target bed with coverage [ 500x: inf),0.024
+COVERAGE SUMMARY,,PCT of target bed with coverage [ 100x: inf),0.035
+COVERAGE SUMMARY,,PCT of target bed with coverage [  50x: inf),4.7
+COVERAGE SUMMARY,,PCT of target bed with coverage [  20x: inf),51.07
+COVERAGE SUMMARY,,PCT of target bed with coverage [  15x: inf),68.09
+COVERAGE SUMMARY,,PCT of target bed with coverage [  10x: inf),71.13
+COVERAGE SUMMARY,,PCT of target bed with coverage [   3x: inf),90.0
+COVERAGE SUMMARY,,PCT of target bed with coverage [   1x: inf),98.83
+COVERAGE SUMMARY,,PCT of target bed with coverage [   0x: inf),100.00
+COVERAGE SUMMARY,,PCT of target bed with coverage [1000x:1500x),0.0
+COVERAGE SUMMARY,,PCT of target bed with coverage [ 500x:1000x),0.0002
+COVERAGE SUMMARY,,PCT of target bed with coverage [ 100x: 500x),0.0003
+COVERAGE SUMMARY,,PCT of target bed with coverage [  50x: 100x),0.48
+COVERAGE SUMMARY,,PCT of target bed with coverage [  20x:  50x),0.5
+COVERAGE SUMMARY,,PCT of target bed with coverage [  15x:  20x),0.47
+COVERAGE SUMMARY,,PCT of target bed with coverage [  10x:  15x),0.52
+COVERAGE SUMMARY,,PCT of target bed with coverage [   3x:  10x),0.88
+COVERAGE SUMMARY,,PCT of target bed with coverage [   1x:   3x),0.13
+COVERAGE SUMMARY,,PCT of target bed with coverage [   0x:   1x),0.009
+COVERAGE SUMMARY,,Average chr X coverage over target bed,95.88
+COVERAGE SUMMARY,,Average chr Y coverage over target bed,99.64
+COVERAGE SUMMARY,,Average mitochondrial coverage over target bed,19.3
+COVERAGE SUMMARY,,Average autosomal coverage over target bed,0.78
+COVERAGE SUMMARY,,Median autosomal coverage over target bed,76.69
+COVERAGE SUMMARY,,Mean/Median autosomal coverage ratio over target bed,12.67
+COVERAGE SUMMARY,,Aligned reads,2867496762
+COVERAGE SUMMARY,,Aligned reads in target bed,3681698840,93.45

--- a/data/modules/dragen/pr_1880/sample_7.target_bed_overall_mean_cov.csv
+++ b/data/modules/dragen/pr_1880/sample_7.target_bed_overall_mean_cov.csv
@@ -1,0 +1,1 @@
+Average alignment coverage over C:/path/to/very_special_region.bed,0.55

--- a/data/modules/dragen/pr_1880/sample_7.wgs_coverage_metrics.csv
+++ b/data/modules/dragen/pr_1880/sample_7.wgs_coverage_metrics.csv
@@ -1,0 +1,33 @@
+COVERAGE SUMMARY,,Aligned bases,2632093055
+COVERAGE SUMMARY,,Aligned bases in genome,1148359507,9.68
+COVERAGE SUMMARY,,Average alignment coverage over genome,75.78
+COVERAGE SUMMARY,,Uniformity of coverage (PCT > 0.2*mean) over genome,46.27
+COVERAGE SUMMARY,,PCT of genome with coverage [1500x: inf),0.01
+COVERAGE SUMMARY,,PCT of genome with coverage [1000x: inf),0.012
+COVERAGE SUMMARY,,PCT of genome with coverage [ 500x: inf),0.03
+COVERAGE SUMMARY,,PCT of genome with coverage [ 100x: inf),0.04
+COVERAGE SUMMARY,,PCT of genome with coverage [  50x: inf),4.56
+COVERAGE SUMMARY,,PCT of genome with coverage [  20x: inf),59.01
+COVERAGE SUMMARY,,PCT of genome with coverage [  15x: inf),67.96
+COVERAGE SUMMARY,,PCT of genome with coverage [  10x: inf),79.63
+COVERAGE SUMMARY,,PCT of genome with coverage [   3x: inf),86.43
+COVERAGE SUMMARY,,PCT of genome with coverage [   1x: inf),91.12
+COVERAGE SUMMARY,,PCT of genome with coverage [   0x: inf),100.00
+COVERAGE SUMMARY,,PCT of genome with coverage [1000x:1500x),0.0002
+COVERAGE SUMMARY,,PCT of genome with coverage [ 500x:1000x),0.001
+COVERAGE SUMMARY,,PCT of genome with coverage [ 100x: 500x),0.0004
+COVERAGE SUMMARY,,PCT of genome with coverage [  50x: 100x),0.85
+COVERAGE SUMMARY,,PCT of genome with coverage [  20x:  50x),0.47
+COVERAGE SUMMARY,,PCT of genome with coverage [  15x:  20x),0.64
+COVERAGE SUMMARY,,PCT of genome with coverage [  10x:  15x),0.88
+COVERAGE SUMMARY,,PCT of genome with coverage [   3x:  10x),0.93
+COVERAGE SUMMARY,,PCT of genome with coverage [   1x:   3x),0.12
+COVERAGE SUMMARY,,PCT of genome with coverage [   0x:   1x),0.0
+COVERAGE SUMMARY,,Average chr X coverage over genome,74.52
+COVERAGE SUMMARY,,Average chr Y coverage over genome,50.45
+COVERAGE SUMMARY,,Average mitochondrial coverage over genome,84.4
+COVERAGE SUMMARY,,Average autosomal coverage over genome,65.02
+COVERAGE SUMMARY,,Median autosomal coverage over genome,33.92
+COVERAGE SUMMARY,,Mean/Median autosomal coverage ratio over genome,42.36
+COVERAGE SUMMARY,,Aligned reads,1987515403
+COVERAGE SUMMARY,,Aligned reads in genome,2874676633,60.94

--- a/data/modules/dragen/pr_1880/sample_7.wgs_overall_mean_cov.csv
+++ b/data/modules/dragen/pr_1880/sample_7.wgs_overall_mean_cov.csv
@@ -1,0 +1,1 @@
+Average alignment coverage over C:/path/to/Whole_genome_756,0.65

--- a/data/modules/dragen/pr_1880/sample_8.qc-coverage-region-1_coverage_metrics.csv
+++ b/data/modules/dragen/pr_1880/sample_8.qc-coverage-region-1_coverage_metrics.csv
@@ -1,0 +1,33 @@
+COVERAGE SUMMARY,,Aligned bases,2797138875
+COVERAGE SUMMARY,,Aligned bases in QC coverage region,1683239998,53.8
+COVERAGE SUMMARY,,Average alignment coverage over QC coverage region,54.23
+COVERAGE SUMMARY,,Uniformity of coverage (PCT > 0.2*mean) over QC coverage region,74.85
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1500x: inf),0.0
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1000x: inf),0.018
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 500x: inf),0.02
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 100x: inf),0.038
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  50x: inf),4.32
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  20x: inf),58.42
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  15x: inf),68.72
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  10x: inf),71.44
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   3x: inf),81.44
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   1x: inf),99.26
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   0x: inf),100.00
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1000x:1500x),0.0005
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 500x:1000x),0.0009
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 100x: 500x),0.0007
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  50x: 100x),0.74
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  20x:  50x),0.53
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  15x:  20x),0.72
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  10x:  15x),0.45
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   3x:  10x),0.75
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   1x:   3x),0.19
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   0x:   1x),0.005
+COVERAGE SUMMARY,,Average chr X coverage over QC coverage region,105.91
+COVERAGE SUMMARY,,Average chr Y coverage over QC coverage region,86.54
+COVERAGE SUMMARY,,Average mitochondrial coverage over QC coverage region,39.3
+COVERAGE SUMMARY,,Average autosomal coverage over QC coverage region,19.51
+COVERAGE SUMMARY,,Median autosomal coverage over QC coverage region,90.73
+COVERAGE SUMMARY,,Mean/Median autosomal coverage ratio over QC coverage region,94.9
+COVERAGE SUMMARY,,Aligned reads,1615886109
+COVERAGE SUMMARY,,Aligned reads in QC coverage region,3361582352,54.06

--- a/data/modules/dragen/pr_1880/sample_8.qc-coverage-region-1_overall_mean_cov.csv
+++ b/data/modules/dragen/pr_1880/sample_8.qc-coverage-region-1_overall_mean_cov.csv
@@ -1,0 +1,1 @@
+Average alignment coverage over C:/path/to/QC_1.bed,0.01

--- a/data/modules/dragen/pr_1880/sample_8.qc-coverage-region-2_coverage_metrics.csv
+++ b/data/modules/dragen/pr_1880/sample_8.qc-coverage-region-2_coverage_metrics.csv
@@ -1,0 +1,33 @@
+COVERAGE SUMMARY,,Aligned bases,2009922504
+COVERAGE SUMMARY,,Aligned bases in QC coverage region,2644466656,23.06
+COVERAGE SUMMARY,,Average alignment coverage over QC coverage region,90.22
+COVERAGE SUMMARY,,Uniformity of coverage (PCT > 0.2*mean) over QC coverage region,78.58
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1500x: inf),0.001
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1000x: inf),0.018
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 500x: inf),0.023
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 100x: inf),0.04
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  50x: inf),4.51
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  20x: inf),50.82
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  15x: inf),61.06
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  10x: inf),73.27
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   3x: inf),89.35
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   1x: inf),91.49
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   0x: inf),100.00
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1000x:1500x),0.001
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 500x:1000x),0.0006
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 100x: 500x),0.0
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  50x: 100x),0.81
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  20x:  50x),0.85
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  15x:  20x),0.77
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  10x:  15x),0.66
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   3x:  10x),0.2
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   1x:   3x),0.11
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   0x:   1x),0.009
+COVERAGE SUMMARY,,Average chr X coverage over QC coverage region,90.22
+COVERAGE SUMMARY,,Average chr Y coverage over QC coverage region,115.88
+COVERAGE SUMMARY,,Average mitochondrial coverage over QC coverage region,40.7
+COVERAGE SUMMARY,,Average autosomal coverage over QC coverage region,50.85
+COVERAGE SUMMARY,,Median autosomal coverage over QC coverage region,44.1
+COVERAGE SUMMARY,,Mean/Median autosomal coverage ratio over QC coverage region,87.96
+COVERAGE SUMMARY,,Aligned reads,3531217211
+COVERAGE SUMMARY,,Aligned reads in QC coverage region,3867109751,14.12

--- a/data/modules/dragen/pr_1880/sample_8.qc-coverage-region-2_overall_mean_cov.csv
+++ b/data/modules/dragen/pr_1880/sample_8.qc-coverage-region-2_overall_mean_cov.csv
@@ -1,0 +1,1 @@
+Average alignment coverage over C:/path/to/QC_2.bed,0.87

--- a/data/modules/dragen/pr_1880/sample_8.target_bed_coverage_metrics.csv
+++ b/data/modules/dragen/pr_1880/sample_8.target_bed_coverage_metrics.csv
@@ -1,0 +1,33 @@
+COVERAGE SUMMARY,,Aligned bases,1409473188
+COVERAGE SUMMARY,,Aligned bases in target bed,3743141724,39.15
+COVERAGE SUMMARY,,Average alignment coverage over target bed,71.35
+COVERAGE SUMMARY,,Uniformity of coverage (PCT > 0.2*mean) over target bed,89.72
+COVERAGE SUMMARY,,PCT of target bed with coverage [1500x: inf),0.008
+COVERAGE SUMMARY,,PCT of target bed with coverage [1000x: inf),0.011
+COVERAGE SUMMARY,,PCT of target bed with coverage [ 500x: inf),0.024
+COVERAGE SUMMARY,,PCT of target bed with coverage [ 100x: inf),0.031
+COVERAGE SUMMARY,,PCT of target bed with coverage [  50x: inf),4.87
+COVERAGE SUMMARY,,PCT of target bed with coverage [  20x: inf),56.46
+COVERAGE SUMMARY,,PCT of target bed with coverage [  15x: inf),68.84
+COVERAGE SUMMARY,,PCT of target bed with coverage [  10x: inf),71.14
+COVERAGE SUMMARY,,PCT of target bed with coverage [   3x: inf),82.54
+COVERAGE SUMMARY,,PCT of target bed with coverage [   1x: inf),92.04
+COVERAGE SUMMARY,,PCT of target bed with coverage [   0x: inf),100.00
+COVERAGE SUMMARY,,PCT of target bed with coverage [1000x:1500x),0.0
+COVERAGE SUMMARY,,PCT of target bed with coverage [ 500x:1000x),0.0005
+COVERAGE SUMMARY,,PCT of target bed with coverage [ 100x: 500x),0.0003
+COVERAGE SUMMARY,,PCT of target bed with coverage [  50x: 100x),0.57
+COVERAGE SUMMARY,,PCT of target bed with coverage [  20x:  50x),0.89
+COVERAGE SUMMARY,,PCT of target bed with coverage [  15x:  20x),0.6
+COVERAGE SUMMARY,,PCT of target bed with coverage [  10x:  15x),0.82
+COVERAGE SUMMARY,,PCT of target bed with coverage [   3x:  10x),0.69
+COVERAGE SUMMARY,,PCT of target bed with coverage [   1x:   3x),0.12
+COVERAGE SUMMARY,,PCT of target bed with coverage [   0x:   1x),0.009
+COVERAGE SUMMARY,,Average chr X coverage over target bed,94.17
+COVERAGE SUMMARY,,Average chr Y coverage over target bed,111.82
+COVERAGE SUMMARY,,Average mitochondrial coverage over target bed,48.9
+COVERAGE SUMMARY,,Average autosomal coverage over target bed,97.18
+COVERAGE SUMMARY,,Median autosomal coverage over target bed,74.25
+COVERAGE SUMMARY,,Mean/Median autosomal coverage ratio over target bed,9.99
+COVERAGE SUMMARY,,Aligned reads,2195136231
+COVERAGE SUMMARY,,Aligned reads in target bed,1017893205,18.26

--- a/data/modules/dragen/pr_1880/sample_8.target_bed_overall_mean_cov.csv
+++ b/data/modules/dragen/pr_1880/sample_8.target_bed_overall_mean_cov.csv
@@ -1,0 +1,1 @@
+Average alignment coverage over C:/path/to/very_special_region.bed,0.51

--- a/data/modules/dragen/pr_1880/sample_8.wgs_coverage_metrics.csv
+++ b/data/modules/dragen/pr_1880/sample_8.wgs_coverage_metrics.csv
@@ -1,0 +1,33 @@
+COVERAGE SUMMARY,,Aligned bases,2174783921
+COVERAGE SUMMARY,,Aligned bases in genome,3691125828,74.91
+COVERAGE SUMMARY,,Average alignment coverage over genome,82.8
+COVERAGE SUMMARY,,Uniformity of coverage (PCT > 0.2*mean) over genome,42.83
+COVERAGE SUMMARY,,PCT of genome with coverage [1500x: inf),0.004
+COVERAGE SUMMARY,,PCT of genome with coverage [1000x: inf),0.017
+COVERAGE SUMMARY,,PCT of genome with coverage [ 500x: inf),0.024
+COVERAGE SUMMARY,,PCT of genome with coverage [ 100x: inf),0.032
+COVERAGE SUMMARY,,PCT of genome with coverage [  50x: inf),4.44
+COVERAGE SUMMARY,,PCT of genome with coverage [  20x: inf),54.77
+COVERAGE SUMMARY,,PCT of genome with coverage [  15x: inf),67.29
+COVERAGE SUMMARY,,PCT of genome with coverage [  10x: inf),71.3
+COVERAGE SUMMARY,,PCT of genome with coverage [   3x: inf),80.45
+COVERAGE SUMMARY,,PCT of genome with coverage [   1x: inf),98.27
+COVERAGE SUMMARY,,PCT of genome with coverage [   0x: inf),100.00
+COVERAGE SUMMARY,,PCT of genome with coverage [1000x:1500x),0.0
+COVERAGE SUMMARY,,PCT of genome with coverage [ 500x:1000x),0.0006
+COVERAGE SUMMARY,,PCT of genome with coverage [ 100x: 500x),0.0004
+COVERAGE SUMMARY,,PCT of genome with coverage [  50x: 100x),0.78
+COVERAGE SUMMARY,,PCT of genome with coverage [  20x:  50x),0.43
+COVERAGE SUMMARY,,PCT of genome with coverage [  15x:  20x),0.55
+COVERAGE SUMMARY,,PCT of genome with coverage [  10x:  15x),0.83
+COVERAGE SUMMARY,,PCT of genome with coverage [   3x:  10x),0.78
+COVERAGE SUMMARY,,PCT of genome with coverage [   1x:   3x),0.15
+COVERAGE SUMMARY,,PCT of genome with coverage [   0x:   1x),0.006
+COVERAGE SUMMARY,,Average chr X coverage over genome,50.21
+COVERAGE SUMMARY,,Average chr Y coverage over genome,85.56
+COVERAGE SUMMARY,,Average mitochondrial coverage over genome,74.6
+COVERAGE SUMMARY,,Average autosomal coverage over genome,53.48
+COVERAGE SUMMARY,,Median autosomal coverage over genome,98.66
+COVERAGE SUMMARY,,Mean/Median autosomal coverage ratio over genome,96.71
+COVERAGE SUMMARY,,Aligned reads,2447257905
+COVERAGE SUMMARY,,Aligned reads in genome,1320441970,38.23

--- a/data/modules/dragen/pr_1880/sample_8.wgs_overall_mean_cov.csv
+++ b/data/modules/dragen/pr_1880/sample_8.wgs_overall_mean_cov.csv
@@ -1,0 +1,1 @@
+Average alignment coverage over C:/path/to/Whole_genome_756,0.51

--- a/data/modules/dragen/pr_1880/sample_9.qc-coverage-region-1_coverage_metrics.csv
+++ b/data/modules/dragen/pr_1880/sample_9.qc-coverage-region-1_coverage_metrics.csv
@@ -1,0 +1,33 @@
+COVERAGE SUMMARY,,Aligned bases,1950542753
+COVERAGE SUMMARY,,Aligned bases in QC coverage region,2154143324,97.3
+COVERAGE SUMMARY,,Average alignment coverage over QC coverage region,48.99
+COVERAGE SUMMARY,,Uniformity of coverage (PCT > 0.2*mean) over QC coverage region,82.28
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1500x: inf),0.004
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1000x: inf),0.016
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 500x: inf),0.027
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 100x: inf),0.037
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  50x: inf),4.77
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  20x: inf),50.15
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  15x: inf),60.01
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  10x: inf),76.24
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   3x: inf),88.16
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   1x: inf),95.78
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   0x: inf),100.00
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1000x:1500x),0.0009
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 500x:1000x),0.0004
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 100x: 500x),0.0009
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  50x: 100x),0.79
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  20x:  50x),0.73
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  15x:  20x),0.53
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  10x:  15x),0.78
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   3x:  10x),0.7
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   1x:   3x),0.14
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   0x:   1x),0.0
+COVERAGE SUMMARY,,Average chr X coverage over QC coverage region,108.6
+COVERAGE SUMMARY,,Average chr Y coverage over QC coverage region,67.61
+COVERAGE SUMMARY,,Average mitochondrial coverage over QC coverage region,65.8
+COVERAGE SUMMARY,,Average autosomal coverage over QC coverage region,30.97
+COVERAGE SUMMARY,,Median autosomal coverage over QC coverage region,76.34
+COVERAGE SUMMARY,,Mean/Median autosomal coverage ratio over QC coverage region,93.84
+COVERAGE SUMMARY,,Aligned reads,2459074006
+COVERAGE SUMMARY,,Aligned reads in QC coverage region,1505954172,30.72

--- a/data/modules/dragen/pr_1880/sample_9.qc-coverage-region-1_overall_mean_cov.csv
+++ b/data/modules/dragen/pr_1880/sample_9.qc-coverage-region-1_overall_mean_cov.csv
@@ -1,0 +1,1 @@
+Average alignment coverage over C:/path/to/QC_1.bed,0.6

--- a/data/modules/dragen/pr_1880/sample_9.qc-coverage-region-2_coverage_metrics.csv
+++ b/data/modules/dragen/pr_1880/sample_9.qc-coverage-region-2_coverage_metrics.csv
@@ -1,0 +1,33 @@
+COVERAGE SUMMARY,,Aligned bases,2747104057
+COVERAGE SUMMARY,,Aligned bases in QC coverage region,2817239239,1.47
+COVERAGE SUMMARY,,Average alignment coverage over QC coverage region,28.74
+COVERAGE SUMMARY,,Uniformity of coverage (PCT > 0.2*mean) over QC coverage region,71.23
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1500x: inf),0.0
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1000x: inf),0.014
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 500x: inf),0.024
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 100x: inf),0.033
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  50x: inf),4.28
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  20x: inf),56.3
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  15x: inf),62.72
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  10x: inf),77.65
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   3x: inf),87.0
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   1x: inf),94.83
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   0x: inf),100.00
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [1000x:1500x),0.001
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 500x:1000x),0.0007
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [ 100x: 500x),0.001
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  50x: 100x),0.45
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  20x:  50x),0.64
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  15x:  20x),0.72
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [  10x:  15x),1.0
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   3x:  10x),0.63
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   1x:   3x),0.12
+COVERAGE SUMMARY,,PCT of QC coverage region with coverage [   0x:   1x),0.009
+COVERAGE SUMMARY,,Average chr X coverage over QC coverage region,79.7
+COVERAGE SUMMARY,,Average chr Y coverage over QC coverage region,23.54
+COVERAGE SUMMARY,,Average mitochondrial coverage over QC coverage region,14.1
+COVERAGE SUMMARY,,Average autosomal coverage over QC coverage region,32.05
+COVERAGE SUMMARY,,Median autosomal coverage over QC coverage region,74.8
+COVERAGE SUMMARY,,Mean/Median autosomal coverage ratio over QC coverage region,24.88
+COVERAGE SUMMARY,,Aligned reads,3706567961
+COVERAGE SUMMARY,,Aligned reads in QC coverage region,2118626005,51.37

--- a/data/modules/dragen/pr_1880/sample_9.qc-coverage-region-2_overall_mean_cov.csv
+++ b/data/modules/dragen/pr_1880/sample_9.qc-coverage-region-2_overall_mean_cov.csv
@@ -1,0 +1,1 @@
+Average alignment coverage over C:/path/to/QC_2.bed,0.03

--- a/data/modules/dragen/pr_1880/sample_9.target_bed_coverage_metrics.csv
+++ b/data/modules/dragen/pr_1880/sample_9.target_bed_coverage_metrics.csv
@@ -1,0 +1,33 @@
+COVERAGE SUMMARY,,Aligned bases,3916470609
+COVERAGE SUMMARY,,Aligned bases in target bed,2372012009,9.67
+COVERAGE SUMMARY,,Average alignment coverage over target bed,16.93
+COVERAGE SUMMARY,,Uniformity of coverage (PCT > 0.2*mean) over target bed,39.39
+COVERAGE SUMMARY,,PCT of target bed with coverage [1500x: inf),0.001
+COVERAGE SUMMARY,,PCT of target bed with coverage [1000x: inf),0.019
+COVERAGE SUMMARY,,PCT of target bed with coverage [ 500x: inf),0.026
+COVERAGE SUMMARY,,PCT of target bed with coverage [ 100x: inf),0.035
+COVERAGE SUMMARY,,PCT of target bed with coverage [  50x: inf),4.51
+COVERAGE SUMMARY,,PCT of target bed with coverage [  20x: inf),55.13
+COVERAGE SUMMARY,,PCT of target bed with coverage [  15x: inf),63.82
+COVERAGE SUMMARY,,PCT of target bed with coverage [  10x: inf),72.99
+COVERAGE SUMMARY,,PCT of target bed with coverage [   3x: inf),82.91
+COVERAGE SUMMARY,,PCT of target bed with coverage [   1x: inf),92.32
+COVERAGE SUMMARY,,PCT of target bed with coverage [   0x: inf),100.00
+COVERAGE SUMMARY,,PCT of target bed with coverage [1000x:1500x),0.0008
+COVERAGE SUMMARY,,PCT of target bed with coverage [ 500x:1000x),0.0001
+COVERAGE SUMMARY,,PCT of target bed with coverage [ 100x: 500x),0.0007
+COVERAGE SUMMARY,,PCT of target bed with coverage [  50x: 100x),0.79
+COVERAGE SUMMARY,,PCT of target bed with coverage [  20x:  50x),0.74
+COVERAGE SUMMARY,,PCT of target bed with coverage [  15x:  20x),0.51
+COVERAGE SUMMARY,,PCT of target bed with coverage [  10x:  15x),0.68
+COVERAGE SUMMARY,,PCT of target bed with coverage [   3x:  10x),0.29
+COVERAGE SUMMARY,,PCT of target bed with coverage [   1x:   3x),0.16
+COVERAGE SUMMARY,,PCT of target bed with coverage [   0x:   1x),0.006
+COVERAGE SUMMARY,,Average chr X coverage over target bed,57.82
+COVERAGE SUMMARY,,Average chr Y coverage over target bed,104.14
+COVERAGE SUMMARY,,Average mitochondrial coverage over target bed,40.0
+COVERAGE SUMMARY,,Average autosomal coverage over target bed,35.08
+COVERAGE SUMMARY,,Median autosomal coverage over target bed,59.61
+COVERAGE SUMMARY,,Mean/Median autosomal coverage ratio over target bed,69.76
+COVERAGE SUMMARY,,Aligned reads,1653101673
+COVERAGE SUMMARY,,Aligned reads in target bed,3818464008,27.79

--- a/data/modules/dragen/pr_1880/sample_9.target_bed_overall_mean_cov.csv
+++ b/data/modules/dragen/pr_1880/sample_9.target_bed_overall_mean_cov.csv
@@ -1,0 +1,1 @@
+Average alignment coverage over C:/path/to/very_special_region.bed,0.87

--- a/data/modules/dragen/pr_1880/sample_9.wgs_coverage_metrics.csv
+++ b/data/modules/dragen/pr_1880/sample_9.wgs_coverage_metrics.csv
@@ -1,0 +1,33 @@
+COVERAGE SUMMARY,,Aligned bases,3818093452
+COVERAGE SUMMARY,,Aligned bases in genome,2874939208,22.87
+COVERAGE SUMMARY,,Average alignment coverage over genome,14.95
+COVERAGE SUMMARY,,Uniformity of coverage (PCT > 0.2*mean) over genome,87.95
+COVERAGE SUMMARY,,PCT of genome with coverage [1500x: inf),0.003
+COVERAGE SUMMARY,,PCT of genome with coverage [1000x: inf),0.015
+COVERAGE SUMMARY,,PCT of genome with coverage [ 500x: inf),0.02
+COVERAGE SUMMARY,,PCT of genome with coverage [ 100x: inf),0.037
+COVERAGE SUMMARY,,PCT of genome with coverage [  50x: inf),4.36
+COVERAGE SUMMARY,,PCT of genome with coverage [  20x: inf),54.32
+COVERAGE SUMMARY,,PCT of genome with coverage [  15x: inf),68.19
+COVERAGE SUMMARY,,PCT of genome with coverage [  10x: inf),73.47
+COVERAGE SUMMARY,,PCT of genome with coverage [   3x: inf),80.81
+COVERAGE SUMMARY,,PCT of genome with coverage [   1x: inf),93.47
+COVERAGE SUMMARY,,PCT of genome with coverage [   0x: inf),100.00
+COVERAGE SUMMARY,,PCT of genome with coverage [1000x:1500x),0.0006
+COVERAGE SUMMARY,,PCT of genome with coverage [ 500x:1000x),0.001
+COVERAGE SUMMARY,,PCT of genome with coverage [ 100x: 500x),0.0009
+COVERAGE SUMMARY,,PCT of genome with coverage [  50x: 100x),0.7
+COVERAGE SUMMARY,,PCT of genome with coverage [  20x:  50x),0.85
+COVERAGE SUMMARY,,PCT of genome with coverage [  15x:  20x),0.66
+COVERAGE SUMMARY,,PCT of genome with coverage [  10x:  15x),0.86
+COVERAGE SUMMARY,,PCT of genome with coverage [   3x:  10x),0.81
+COVERAGE SUMMARY,,PCT of genome with coverage [   1x:   3x),0.17
+COVERAGE SUMMARY,,PCT of genome with coverage [   0x:   1x),0.001
+COVERAGE SUMMARY,,Average chr X coverage over genome,47.89
+COVERAGE SUMMARY,,Average chr Y coverage over genome,98.66
+COVERAGE SUMMARY,,Average mitochondrial coverage over genome,53.8
+COVERAGE SUMMARY,,Average autosomal coverage over genome,81.4
+COVERAGE SUMMARY,,Median autosomal coverage over genome,41.06
+COVERAGE SUMMARY,,Mean/Median autosomal coverage ratio over genome,4.05
+COVERAGE SUMMARY,,Aligned reads,2374886975
+COVERAGE SUMMARY,,Aligned reads in genome,1778145374,12.86

--- a/data/modules/dragen/pr_1880/sample_9.wgs_overall_mean_cov.csv
+++ b/data/modules/dragen/pr_1880/sample_9.wgs_overall_mean_cov.csv
@@ -1,0 +1,1 @@
+Average alignment coverage over C:/path/to/Whole_genome_756,0.91


### PR DESCRIPTION
This adds test coverage metrics data from `test_coverage_data.zip` in PR ewels/MultiQC#1880 by @Just-Roma

Associated issue: ewels/MultiQC#1781