### PR TITLE
More data for UMICollapse

### DIFF
--- a/data/modules/umicollapse/SRR19887561.umi_dedup.sorted_UMICollapse.log
+++ b/data/modules/umicollapse/SRR19887561.umi_dedup.sorted_UMICollapse.log
@@ -1,0 +1,12 @@
+Arguments	[bam, -i, SRR19887561.sorted.bam, -o, SRR19887561.umi_dedup.sorted.bam, --paired, --two-pass, --remove-unpaired, --remove-chimeric, --algo, dir]
+Done with the first pass!
+Number of input reads	61705512
+Number of removed unmapped reads	65823
+Number of unpaired reads	0
+Number of chimeric reads	0
+Number of unremoved reads	61639689
+Number of unique alignment positions	25668522
+Average number of UMIs per alignment position	1.3810855568544227
+Max number of UMIs over all alignment positions	810
+Number of reads after deduplicating	32649816
+UMI collapsing finished in 1270.096 seconds!

--- a/data/modules/umicollapse/SRR19887562.umi_dedup.sorted_UMICollapse.log
+++ b/data/modules/umicollapse/SRR19887562.umi_dedup.sorted_UMICollapse.log
@@ -1,0 +1,12 @@
+Arguments	[bam, -i, SRR19887562.sorted.bam, -o, SRR19887562.umi_dedup.sorted.bam, --paired, --two-pass, --remove-unpaired, --remove-chimeric, --algo, dir]
+Done with the first pass!
+Number of input reads	37340138
+Number of removed unmapped reads	22176
+Number of unpaired reads	0
+Number of chimeric reads	0
+Number of unremoved reads	37317962
+Number of unique alignment positions	18414304
+Average number of UMIs per alignment position	1.283159222308918
+Max number of UMIs over all alignment positions	570
+Number of reads after deduplicating	22381547
+UMI collapsing finished in 829.069 seconds!

--- a/data/modules/umicollapse/SRR19887563.umi_dedup.sorted_UMICollapse.log
+++ b/data/modules/umicollapse/SRR19887563.umi_dedup.sorted_UMICollapse.log
@@ -1,0 +1,12 @@
+Arguments	[bam, -i, SRR19887563.sorted.bam, -o, SRR19887563.umi_dedup.sorted.bam, --paired, --two-pass, --remove-unpaired, --remove-chimeric, --algo, dir]
+Done with the first pass!
+Number of input reads	60934923
+Number of removed unmapped reads	27053
+Number of unpaired reads	0
+Number of chimeric reads	0
+Number of unremoved reads	60907870
+Number of unique alignment positions	27191754
+Average number of UMIs per alignment position	1.3041034425362925
+Max number of UMIs over all alignment positions	190
+Number of reads after deduplicating	33453003
+UMI collapsing finished in 1253.371 seconds!

--- a/data/modules/umicollapse/SRR19887564.umi_dedup.sorted_UMICollapse.log
+++ b/data/modules/umicollapse/SRR19887564.umi_dedup.sorted_UMICollapse.log
@@ -1,0 +1,12 @@
+Arguments	[bam, -i, SRR19887564.sorted.bam, -o, SRR19887564.umi_dedup.sorted.bam, --paired, --two-pass, --remove-unpaired, --remove-chimeric, --algo, dir]
+Done with the first pass!
+Number of input reads	61102320
+Number of removed unmapped reads	36688
+Number of unpaired reads	0
+Number of chimeric reads	0
+Number of unremoved reads	61065632
+Number of unique alignment positions	25880680
+Average number of UMIs per alignment position	1.3413553276034478
+Max number of UMIs over all alignment positions	200
+Number of reads after deduplicating	32424562
+UMI collapsing finished in 1257.136 seconds!

--- a/data/modules/umicollapse/SRR19887565.umi_dedup.sorted_UMICollapse.log
+++ b/data/modules/umicollapse/SRR19887565.umi_dedup.sorted_UMICollapse.log
@@ -1,0 +1,12 @@
+Arguments	[bam, -i, SRR19887565.sorted.bam, -o, SRR19887565.umi_dedup.sorted.bam, --paired, --two-pass, --remove-unpaired, --remove-chimeric, --algo, dir]
+Done with the first pass!
+Number of input reads	89347571
+Number of removed unmapped reads	35347
+Number of unpaired reads	0
+Number of chimeric reads	0
+Number of unremoved reads	89312224
+Number of unique alignment positions	21996792
+Average number of UMIs per alignment position	1.5272988897653803
+Max number of UMIs over all alignment positions	211
+Number of reads after deduplicating	30030141
+UMI collapsing finished in 1419.32 seconds!

--- a/data/modules/umicollapse/SRR19887566.umi_dedup.sorted_UMICollapse.log
+++ b/data/modules/umicollapse/SRR19887566.umi_dedup.sorted_UMICollapse.log
@@ -1,0 +1,12 @@
+Arguments	[bam, -i, SRR19887566.sorted.bam, -o, SRR19887566.umi_dedup.sorted.bam, --paired, --two-pass, --remove-unpaired, --remove-chimeric, --algo, dir]
+Done with the first pass!
+Number of input reads	33927831
+Number of removed unmapped reads	19760
+Number of unpaired reads	0
+Number of chimeric reads	0
+Number of unremoved reads	33908071
+Number of unique alignment positions	16228599
+Average number of UMIs per alignment position	1.3046860668625802
+Max number of UMIs over all alignment positions	577
+Number of reads after deduplicating	20036292
+UMI collapsing finished in 763.948 seconds!

--- a/data/modules/umicollapse/SRR19887567.umi_dedup.sorted_UMICollapse.log
+++ b/data/modules/umicollapse/SRR19887567.umi_dedup.sorted_UMICollapse.log
@@ -1,0 +1,12 @@
+Arguments	[bam, -i, SRR19887567.sorted.bam, -o, SRR19887567.umi_dedup.sorted.bam, --paired, --two-pass, --remove-unpaired, --remove-chimeric, --algo, dir]
+Done with the first pass!
+Number of input reads	59475470
+Number of removed unmapped reads	27814
+Number of unpaired reads	0
+Number of chimeric reads	0
+Number of unremoved reads	59447656
+Number of unique alignment positions	21269429
+Average number of UMIs per alignment position	1.4052952244275105
+Max number of UMIs over all alignment positions	176
+Number of reads after deduplicating	27610095
+UMI collapsing finished in 1139.719 seconds!

--- a/data/modules/umicollapse/SRR19887568.umi_dedup.sorted_UMICollapse.log
+++ b/data/modules/umicollapse/SRR19887568.umi_dedup.sorted_UMICollapse.log
@@ -1,4 +1,5 @@
 Arguments	[bam, -i, SRR19887568.sorted.bam, -o, SRR19887568.umi_dedup.sorted.bam, --paired, --two-pass, --remove-unpaired, --remove-chimeric, --algo, dir]
+Done with the first pass!
 Number of input reads	53490614
 Number of removed unmapped reads	24260
 Number of unpaired reads	0
@@ -7,4 +8,5 @@ Number of unremoved reads	53466354
 Number of unique alignment positions	21532282
 Average number of UMIs per alignment position	1.3478738110526325
 Max number of UMIs over all alignment positions	165
+Number of reads after deduplicating	27208411
 UMI collapsing finished in 1077.717 seconds!


### PR DESCRIPTION
Also fixes a missing line in the existing single file that was initially absent in https://github.com/MultiQC/MultiQC/pull/2814. With the added line, all plots and tables will be rendered.