### PR TITLE
Add example data for UMICollapse in FastQ mode.

### DIFF
--- a/data/modules/umicollapse/umicollapse-fastq.log
+++ b/data/modules/umicollapse/umicollapse-fastq.log
@@ -1,0 +1,6 @@
+Arguments	[fastq, -i, example.fq.gz, -o, example_dedup.fq.gz]
+Done reading input file into memory!
+Number of input reads	250000
+Number of unique reads	176706
+Number of reads after deduplicating	156633
+UMI collapsing finished in 8.169 seconds!


### PR DESCRIPTION
Wonderful that there is now a module for UMICollapse! However, UMICollapse also has a FastQ mode that is not supported by the module in its current form. Hence, I provide some additional test data to underpin the PR.