### PR TITLE
Update bbsplit refstats data

### DIFF
--- a/data/modules/bbmap/sample1/sample1.refstats.txt
+++ b/data/modules/bbmap/sample1/sample1.refstats.txt
@@ -1,3 +1,3 @@
-#name   %unambiguousReads       unambiguousMB   %ambiguousReads ambiguousMB     unambiguousReads        ambiguousReads
-hg38    83.16030        5598.96128      1.11830 51.55901        87337366        1174470
-mm38    15.56726        1051.54145      1.11830 51.55901        16349186        1174470
+#name	%unambiguousReads	unambiguousMB	%ambiguousReads	ambiguousMB	unambiguousReads	ambiguousReads	assignedReads	assignedBases
+primary	50.00000	0.324921	0.00000	0.000000	4000	0	4000	324921
+human	50.00000	0.325030	0.00000	0.000000	4000	0	4000	325030


### PR DESCRIPTION
The previous version of the bbsplit refstats output data used spaces insteads of tabs as delimiters and was missing the final two columns (assignedReads and assignedBases).

```
└─▶ cat -t sample1.refstats.txt 
#name   %unambiguousReads       unambiguousMB   %ambiguousReads ambiguousMB     unambiguousReads        ambiguousReads
hg38    83.16030        5598.96128      1.11830 51.55901        87337366        1174470
mm38    15.56726        1051.54145      1.11830 51.55901        16349186        1174470
```

versus 

```
└─▶ cat -t sample1.refstats.txt 
#name^I%unambiguousReads^IunambiguousMB^I%ambiguousReads^IambiguousMB^IunambiguousReads^IambiguousReads^IassignedReads^IassignedBases
primary^I50.00000^I0.324921^I0.00000^I0.000000^I4000^I0^I4000^I324921
human^I50.00000^I0.325030^I0.00000^I0.000000^I4000^I0^I4000^I325030
```

The new output was created using v39.10 of BBTools (installed via bioconda).

```
java -ea -Xmx16924m -Xms16924m -cp /home/pmoris/mambaforge/envs/bbsplit/opt/bbmap-39.10-0/current/ align2.BBSplitter ow=t fastareadlen=500 minhits=1 minratio=0.56 maxindel=20 qtrim=rl untrim=t trimq=6 --version
BBTools version 39.10
For help, please run the shellscript with no parameters, or look in /docs/.
```