### PR TITLE
Add test data for the Citations module

### DIFF
--- a/data/modules/citations/pipeline.citations.bib
+++ b/data/modules/citations/pipeline.citations.bib
@@ -1,0 +1,8 @@
+@software{bwa,
+  title    = {Fast and accurate short read alignment with {Burrows-Wheeler} transform},
+  author   = {Li, Heng and Durbin, Richard},
+  year     = {2009},
+  journal  = {Bioinformatics},
+  doi      = {10.1093/bioinformatics/btp324},
+  version  = {0.7.17}
+}

--- a/data/modules/citations/pipeline_citations.csl.json
+++ b/data/modules/citations/pipeline_citations.csl.json
@@ -1,0 +1,33 @@
+[
+  {
+    "id": "fastqc",
+    "type": "software",
+    "title": "FastQC: A Quality Control Tool for High Throughput Sequence Data",
+    "author": [{ "family": "Andrews", "given": "S" }],
+    "issued": { "date-parts": [[2010]] },
+    "container-title": "Bioinformatics",
+    "DOI": "10.1093/bioinformatics/btv033",
+    "URL": "https://www.bioinformatics.babraham.ac.uk/projects/fastqc/",
+    "custom": { "tool": "fastqc", "version": "0.12.1" }
+  },
+  {
+    "id": "samtools",
+    "type": "article-journal",
+    "title": "Twelve years of SAMtools and BCFtools",
+    "author": [
+      { "family": "Danecek", "given": "P" },
+      { "family": "Bonfield", "given": "J K" }
+    ],
+    "issued": { "date-parts": [[2021]] },
+    "container-title": "GigaScience",
+    "DOI": "10.1093/gigascience/giab008",
+    "URL": "http://www.htslib.org/",
+    "custom": { "tool": "samtools", "version": "1.21" }
+  },
+  {
+    "id": "snpsift",
+    "type": "software",
+    "DOI": "10.5281/zenodo.1234567",
+    "custom": { "tool": "snpsift", "version": "5.2" }
+  }
+]


### PR DESCRIPTION
Companion test data for the new MultiQC `citations` module (MultiQC/MultiQC PR linked below).

Adds `data/modules/citations/`:
- `pipeline_citations.csl.json` — CSL-JSON: single-author (fastqc), multi-author (samtools), DOI-only/no-publication (snpsift), each with a runtime `custom.version`.
- `pipeline.citations.bib` — BibTeX: multi-author entry (bwa) with a `version` field.

Exercised by `tests/test_modules_run.py::test_all_modules[citations]` and `test_ignore_samples[citations]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)