### PR TITLE
Add test data for covsnap module

### DIFF
--- a/data/modules/covsnap/NA12878_panel.covsnap.json
+++ b/data/modules/covsnap/NA12878_panel.covsnap.json
@@ -1,0 +1,164 @@
+{
+  "covsnap_version": "0.5.0",
+  "schema_version": "1.0",
+  "run": {
+    "sample_name": "NA12878_panel",
+    "bam_path": "/data/NA12878_panel.bam",
+    "reference": null,
+    "engine_used": "mosdepth",
+    "engine_version": "0.3.8",
+    "contig_style": "chr",
+    "run_date": "2026-06-29",
+    "bed_path": null,
+    "exon_only": false,
+    "thresholds": [
+      1,
+      5,
+      10,
+      20,
+      30,
+      50,
+      100
+    ],
+    "classify_params": {
+      "pass_pct_ge_20": 95.0,
+      "pass_max_pct_zero": 1.0,
+      "dropout_pct_zero": 5.0,
+      "dropout_zero_block_bp": 500,
+      "uneven_cv": 1.0,
+      "exon_pct_ge_20": 90.0,
+      "exon_max_pct_zero": 5.0
+    }
+  },
+  "summary": {
+    "n_targets": 2,
+    "n_pass": 2,
+    "status_counts": {
+      "PASS": 2
+    }
+  },
+  "targets": [
+    {
+      "target_id": "BRCA1",
+      "contig": "chr17",
+      "start": 43044294,
+      "end": 43125483,
+      "length_bp": 81189,
+      "mean_depth": 142.3,
+      "median_depth": 140.0,
+      "min_depth": 3,
+      "max_depth": 310,
+      "stdev_depth": 38.1,
+      "pct_zero": 0.12,
+      "pct_thresholds": {
+        "1": 99.9,
+        "5": 99.9,
+        "10": 99.9,
+        "20": 98.6,
+        "30": 98.6,
+        "50": 84.8,
+        "100": 71.0
+      },
+      "coverage_status": "PASS",
+      "n_lowcov_blocks": 0,
+      "lowcov_total_bp": 0,
+      "lowcov_blocks": [],
+      "histogram": {
+        "0": 96,
+        "30": 400,
+        "140": 12000
+      },
+      "exons": [
+        {
+          "target_id": "BRCA1_exon1",
+          "contig": "chr17",
+          "start": 43125270,
+          "end": 43125483,
+          "length_bp": 213,
+          "mean_depth": 150.0,
+          "median_depth": 149.0,
+          "min_depth": 40,
+          "max_depth": 210,
+          "stdev_depth": 22.0,
+          "pct_zero": 0.0,
+          "pct_thresholds": {
+            "1": 100.0,
+            "5": 100.0,
+            "10": 100.0,
+            "20": 100.0,
+            "30": 100.0,
+            "50": 90.0,
+            "100": 80.0
+          },
+          "coverage_status": "OK",
+          "n_lowcov_blocks": 0,
+          "lowcov_total_bp": 0,
+          "lowcov_blocks": [],
+          "histogram": {},
+          "exon_number": 1,
+          "status": "OK"
+        },
+        {
+          "target_id": "BRCA1_exon2",
+          "contig": "chr17",
+          "start": 43124016,
+          "end": 43124114,
+          "length_bp": 98,
+          "mean_depth": 138.0,
+          "median_depth": 140.0,
+          "min_depth": 55,
+          "max_depth": 190,
+          "stdev_depth": 19.0,
+          "pct_zero": 0.0,
+          "pct_thresholds": {
+            "1": 100.0,
+            "5": 100.0,
+            "10": 100.0,
+            "20": 100.0,
+            "30": 100.0,
+            "50": 86.0,
+            "100": 72.0
+          },
+          "coverage_status": "OK",
+          "n_lowcov_blocks": 0,
+          "lowcov_total_bp": 0,
+          "lowcov_blocks": [],
+          "histogram": {},
+          "exon_number": 2,
+          "status": "OK"
+        }
+      ]
+    },
+    {
+      "target_id": "TP53",
+      "contig": "chr17",
+      "start": 7668401,
+      "end": 7694173,
+      "length_bp": 25772,
+      "mean_depth": 160.0,
+      "median_depth": 158.0,
+      "min_depth": 20,
+      "max_depth": 300,
+      "stdev_depth": 30.0,
+      "pct_zero": 0.0,
+      "pct_thresholds": {
+        "1": 100.0,
+        "5": 100.0,
+        "10": 100.0,
+        "20": 99.5,
+        "30": 99.5,
+        "50": 89.75,
+        "100": 80.0
+      },
+      "coverage_status": "PASS",
+      "n_lowcov_blocks": 0,
+      "lowcov_total_bp": 0,
+      "lowcov_blocks": [],
+      "histogram": {
+        "50": 2000,
+        "160": 15000
+      }
+    }
+  ],
+  "genes": []
+}

--- a/data/modules/covsnap/sampleB_lowcov.covsnap.json
+++ b/data/modules/covsnap/sampleB_lowcov.covsnap.json
@@ -1,0 +1,120 @@
+{
+  "covsnap_version": "0.5.0",
+  "schema_version": "1.0",
+  "run": {
+    "sample_name": "sampleB_lowcov",
+    "bam_path": "/data/sampleB_lowcov.bam",
+    "reference": null,
+    "engine_used": "mosdepth",
+    "engine_version": "0.3.8",
+    "contig_style": "chr",
+    "run_date": "2026-06-29",
+    "bed_path": null,
+    "exon_only": false,
+    "thresholds": [
+      1,
+      5,
+      10,
+      20,
+      30,
+      50,
+      100
+    ],
+    "classify_params": {
+      "pass_pct_ge_20": 95.0,
+      "pass_max_pct_zero": 1.0,
+      "dropout_pct_zero": 5.0,
+      "dropout_zero_block_bp": 500,
+      "uneven_cv": 1.0,
+      "exon_pct_ge_20": 90.0,
+      "exon_max_pct_zero": 5.0
+    }
+  },
+  "summary": {
+    "n_targets": 2,
+    "n_pass": 0,
+    "status_counts": {
+      "LOW_COVERAGE": 1,
+      "DROP_OUT": 1
+    }
+  },
+  "targets": [
+    {
+      "target_id": "BRCA1",
+      "contig": "chr17",
+      "start": 43044294,
+      "end": 43125483,
+      "length_bp": 81189,
+      "mean_depth": 55.0,
+      "median_depth": 52.0,
+      "min_depth": 0,
+      "max_depth": 140,
+      "stdev_depth": 16.0,
+      "pct_zero": 4.2,
+      "pct_thresholds": {
+        "1": 96.0,
+        "5": 96.0,
+        "10": 96.0,
+        "20": 70.0,
+        "30": 70.0,
+        "50": 37.5,
+        "100": 5.0
+      },
+      "coverage_status": "LOW_COVERAGE",
+      "n_lowcov_blocks": 1,
+      "lowcov_total_bp": 600,
+      "lowcov_blocks": [
+        {
+          "contig": "chr17",
+          "start": 43100000,
+          "end": 43100600,
+          "length": 600,
+          "mean_depth": 2.1
+        }
+      ],
+      "histogram": {
+        "0": 3400,
+        "50": 40000
+      }
+    },
+    {
+      "target_id": "ETFDH",
+      "contig": "chr4",
+      "start": 158680400,
+      "end": 158716400,
+      "length_bp": 36000,
+      "mean_depth": 0.8,
+      "median_depth": 0.0,
+      "min_depth": 0,
+      "max_depth": 12,
+      "stdev_depth": 1.5,
+      "pct_zero": 82.0,
+      "pct_thresholds": {
+        "1": 18.0,
+        "5": 18.0,
+        "10": 18.0,
+        "20": 3.0,
+        "30": 3.0,
+        "50": 1.5,
+        "100": 0.0
+      },
+      "coverage_status": "DROP_OUT",
+      "n_lowcov_blocks": 1,
+      "lowcov_total_bp": 29600,
+      "lowcov_blocks": [
+        {
+          "contig": "chr4",
+          "start": 158680400,
+          "end": 158710000,
+          "length": 29600,
+          "mean_depth": 0.2
+        }
+      ],
+      "histogram": {
+        "0": 29600,
+        "5": 6400
+      }
+    }
+  ],
+  "genes": []
+}

--- a/data/modules/covsnap/sampleC_uneven.covsnap.json
+++ b/data/modules/covsnap/sampleC_uneven.covsnap.json
@@ -1,0 +1,105 @@
+{
+  "covsnap_version": "0.5.0",
+  "schema_version": "1.0",
+  "run": {
+    "sample_name": "sampleC_uneven",
+    "bam_path": "/data/sampleC_uneven.bam",
+    "reference": null,
+    "engine_used": "mosdepth",
+    "engine_version": "0.3.8",
+    "contig_style": "chr",
+    "run_date": "2026-06-29",
+    "bed_path": null,
+    "exon_only": false,
+    "thresholds": [
+      1,
+      5,
+      10,
+      20,
+      30,
+      50,
+      100
+    ],
+    "classify_params": {
+      "pass_pct_ge_20": 95.0,
+      "pass_max_pct_zero": 1.0,
+      "dropout_pct_zero": 5.0,
+      "dropout_zero_block_bp": 500,
+      "uneven_cv": 1.0,
+      "exon_pct_ge_20": 90.0,
+      "exon_max_pct_zero": 5.0
+    }
+  },
+  "summary": {
+    "n_targets": 2,
+    "n_pass": 1,
+    "status_counts": {
+      "UNEVEN": 1,
+      "PASS": 1
+    }
+  },
+  "targets": [
+    {
+      "target_id": "EGFR",
+      "contig": "chr7",
+      "start": 55019016,
+      "end": 55211627,
+      "length_bp": 192611,
+      "mean_depth": 210.0,
+      "median_depth": 180.0,
+      "min_depth": 0,
+      "max_depth": 1400,
+      "stdev_depth": 260.0,
+      "pct_zero": 0.3,
+      "pct_thresholds": {
+        "1": 99.0,
+        "5": 99.0,
+        "10": 99.0,
+        "20": 96.0,
+        "30": 96.0,
+        "50": 78.0,
+        "100": 60.0
+      },
+      "coverage_status": "UNEVEN",
+      "n_lowcov_blocks": 0,
+      "lowcov_total_bp": 0,
+      "lowcov_blocks": [],
+      "histogram": {
+        "0": 600,
+        "180": 80000,
+        "1400": 200
+      }
+    },
+    {
+      "target_id": "KRAS",
+      "contig": "chr12",
+      "start": 25204788,
+      "end": 25250462,
+      "length_bp": 45674,
+      "mean_depth": 120.0,
+      "median_depth": 119.0,
+      "min_depth": 30,
+      "max_depth": 240,
+      "stdev_depth": 28.0,
+      "pct_zero": 0.0,
+      "pct_thresholds": {
+        "1": 100.0,
+        "5": 100.0,
+        "10": 100.0,
+        "20": 99.0,
+        "30": 99.0,
+        "50": 84.5,
+        "100": 70.0
+      },
+      "coverage_status": "PASS",
+      "n_lowcov_blocks": 0,
+      "lowcov_total_bp": 0,
+      "lowcov_blocks": [],
+      "histogram": {
+        "30": 1000,
+        "120": 40000
+      }
+    }
+  ],
+  "genes": []
+}


### PR DESCRIPTION
Adds example data for the new covsnap module proposed in MultiQC/MultiQC#3599.

`data/modules/covsnap/` contains three covsnap JSON reports (`covsnap --format json`) covering the full range of classifications: PASS, LOW_COVERAGE, UNEVEN, and DROP_OUT. The files include per-exon detail, low-coverage blocks, and depth histograms so the module is exercised on realistic input.

Required for the `test_all_modules` and `test_ignore_samples` checks on the module PR.