### PR TITLE
Add DotMatch module fixtures

### DIFF
--- a/data/modules/dotmatch/dotmatch_crispr_qc.summary.tsv
+++ b/data/modules/dotmatch/dotmatch_crispr_qc.summary.tsv
@@ -1,0 +1,3 @@
+sample_id	qc_status	total_count	coverage_fraction	zero_count_fraction	gini_index	top_1pct_fraction	assignment_rate	ambiguous_rate	no_match_rate	invalid_rate
+sample_a	pass	95	0.950000	0.050000	0.180000	0.040000	0.959596	0.010101	0.030303	0.010101
+sample_b	review	82	0.820000	0.180000	0.220000	0.060000	0.932203	0.012712	0.042373	0.016949

--- a/data/modules/dotmatch/dotmatch_sample_qc.tsv
+++ b/data/modules/dotmatch/dotmatch_sample_qc.tsv
@@ -1,0 +1,3 @@
+sample_id	fastq	total_reads	valid_extracted_reads	assigned_reads	exact_reads	k1_rescued_reads	k1_sub_reads	k1_ins_reads	k1_del_reads	ambiguous_reads	no_match_reads	invalid_reads	assignment_rate	exact_rate	rescue_rate	ambiguous_rate	no_match_rate	targets_observed	zero_count_targets	gini_index	top_1pct_read_fraction	candidates_verified
+sample_a	sample_a.fastq	1000	990	950	900	50	45	3	2	10	30	10	0.959596	0.909091	0.050505	0.010101	0.030303	100	5	0.180000	0.040000	120
+sample_b	sample_b.fastq	1200	1180	1100	1000	100	90	6	4	15	50	20	0.932203	0.847458	0.084746	0.012712	0.042373	110	8	0.220000	0.060000	140


### PR DESCRIPTION
Adds minimal public fixtures for the DotMatch MultiQC module.

The files exercise the stable `sample_qc.tsv` and `crispr_qc.summary.tsv` report headers used by the module. They are intentionally small and contain no external sample data.

These fixtures are referenced by MultiQC PR #TODO and allow the blanket module-run test to exercise the new module.