### PR TITLE
Add OrthoFinder example output

### DIFF
--- a/data/modules/orthofinder/Results_Mycoplasma_v3.1.5/Comparative_Genomics_Statistics/Statistics_Overall.tsv
+++ b/data/modules/orthofinder/Results_Mycoplasma_v3.1.5/Comparative_Genomics_Statistics/Statistics_Overall.tsv
@@ -1,0 +1,52 @@
+Number of species	4
+Number of genes	2733
+Number of genes in orthogroups	2216
+Number of unassigned genes	517
+Percentage of genes in orthogroups	81.1
+Percentage of unassigned genes	18.9
+Number of orthogroups	599
+Number of species-specific orthogroups	84
+Number of genes in species-specific orthogroups	379
+Percentage of genes in species-specific orthogroups	13.9
+Mean orthogroup size	3.7
+Median orthogroup size	4.0
+G50 (assigned genes)	4
+G50 (all genes)	4
+O50 (assigned genes)	213
+O50 (all genes)	278
+Number of orthogroups with all species present	274
+Number of single-copy orthogroups	250
+Date	2026-08-30
+Orthogroups file	Orthogroups.tsv
+Unassigned genes file	Orthogroups_UnassignedGenes.tsv
+Per-species statistics	Statistics_PerSpecies.tsv
+Overall statistics	Statistics_Overall.tsv
+Orthogroups shared between species	Orthogroups_SpeciesOverlaps.tsv
+
+Average number of genes per-species in orthogroup	Number of orthogroups	Percentage of orthogroups	Number of genes	Percentage of genes
+<1	268	44.7	636	28.7
+'1	318	53.1	1339	60.4
+'2	4	0.7	36	1.6
+'3	6	1.0	80	3.6
+'4	1	0.2	16	0.7
+'5	0	0.0	0	0.0
+'6	0	0.0	0	0.0
+'7	0	0.0	0	0.0
+'8	0	0.0	0	0.0
+'9	0	0.0	0	0.0
+'10	0	0.0	0	0.0
+11-15	2	0.3	109	4.9
+16-20	0	0.0	0	0.0
+21-50	0	0.0	0	0.0
+51-100	0	0.0	0	0.0
+101-150	0	0.0	0	0.0
+151-200	0	0.0	0	0.0
+201-500	0	0.0	0	0.0
+501-1000	0	0.0	0	0.0
+'1001+	0	0.0	0	0.0
+
+Number of species in orthogroup	Number of orthogroups
+1	84
+2	158
+3	83
+4	274

--- a/data/modules/orthofinder/Results_Mycoplasma_v3.1.5/Comparative_Genomics_Statistics/Statistics_PerSpecies.tsv
+++ b/data/modules/orthofinder/Results_Mycoplasma_v3.1.5/Comparative_Genomics_Statistics/Statistics_PerSpecies.tsv
@@ -1,0 +1,100 @@
+	Mycoplasma_agalactiae	Mycoplasma_gallisepticum	Mycoplasma_genitalium	Mycoplasma_hyopneumoniae
+Number of genes	820	763	476	674
+Number of genes in orthogroups	650	597	417	552
+Number of unassigned genes	170	166	59	122
+Percentage of genes in orthogroups	79.3	78.2	87.6	81.9
+Percentage of unassigned genes	20.7	21.8	12.4	18.1
+Number of orthogroups containing species	458	457	388	442
+Percentage of orthogroups containing species	76.5	76.3	64.8	73.8
+Number of species-specific orthogroups	37	11	3	33
+Number of genes in species-specific orthogroups	171	95	6	107
+Percentage of genes in species-specific orthogroups	20.9	12.5	1.3	15.9
+
+
+Number of genes per-species in orthogroup	Number of orthogroups	Number of orthogroups	Number of orthogroups	Number of orthogroups
+'0	141	142	211	157
+'1	387	418	364	394
+'2	33	27	19	24
+'3	25	4	5	11
+'4	5	1	0	4
+'5	4	1	0	3
+'6	1	0	0	2
+'7	0	1	0	2
+'8	0	2	0	1
+'9	0	0	0	0
+'10	1	1	0	0
+11-15	1	1	0	1
+16-20	0	0	0	0
+21-50	0	0	0	0
+51-100	1	1	0	0
+101-150	0	0	0	0
+151-200	0	0	0	0
+201-500	0	0	0	0
+501-1000	0	0	0	0
+'1001+	0	0	0	0
+
+Number of genes per-species in orthogroup	Percentage of orthogroups	Percentage of orthogroups	Percentage of orthogroups	Percentage of orthogroups
+'0	23.5	23.7	35.2	26.2
+'1	64.6	69.8	60.8	65.8
+'2	5.5	4.5	3.2	4.0
+'3	4.2	0.7	0.8	1.8
+'4	0.8	0.2	0.0	0.7
+'5	0.7	0.2	0.0	0.5
+'6	0.2	0.0	0.0	0.3
+'7	0.0	0.2	0.0	0.3
+'8	0.0	0.3	0.0	0.2
+'9	0.0	0.0	0.0	0.0
+'10	0.2	0.2	0.0	0.0
+11-15	0.2	0.2	0.0	0.2
+16-20	0.0	0.0	0.0	0.0
+21-50	0.0	0.0	0.0	0.0
+51-100	0.2	0.2	0.0	0.0
+101-150	0.0	0.0	0.0	0.0
+151-200	0.0	0.0	0.0	0.0
+201-500	0.0	0.0	0.0	0.0
+501-1000	0.0	0.0	0.0	0.0
+'1001+	0.0	0.0	0.0	0.0
+
+Number of genes per-species in orthogroup	Number of genes	Number of genes	Number of genes	Number of genes
+'0	0	0	0	0
+'1	387	418	364	394
+'2	66	54	38	48
+'3	75	12	15	33
+'4	20	4	0	16
+'5	20	5	0	15
+'6	6	0	0	12
+'7	0	7	0	14
+'8	0	16	0	8
+'9	0	0	0	0
+'10	10	10	0	0
+11-15	15	13	0	12
+16-20	0	0	0	0
+21-50	0	0	0	0
+51-100	51	58	0	0
+101-150	0	0	0	0
+151-200	0	0	0	0
+201-500	0	0	0	0
+501-1000	0	0	0	0
+'1001+	0	0	0	0
+
+Number of genes per-species in orthogroup	Percentage of genes	Percentage of genes	Percentage of genes	Percentage of genes
+'0	0.0	0.0	0.0	0.0
+'1	47.2	54.8	76.5	58.5
+'2	8.0	7.1	8.0	7.1
+'3	9.1	1.6	3.2	4.9
+'4	2.4	0.5	0.0	2.4
+'5	2.4	0.7	0.0	2.2
+'6	0.7	0.0	0.0	1.8
+'7	0.0	0.9	0.0	2.1
+'8	0.0	2.1	0.0	1.2
+'9	0.0	0.0	0.0	0.0
+'10	1.2	1.3	0.0	0.0
+11-15	1.8	1.7	0.0	1.8
+16-20	0.0	0.0	0.0	0.0
+21-50	0.0	0.0	0.0	0.0
+51-100	6.2	7.6	0.0	0.0
+101-150	0.0	0.0	0.0	0.0
+151-200	0.0	0.0	0.0	0.0
+201-500	0.0	0.0	0.0	0.0
+501-1000	0.0	0.0	0.0	0.0
+'1001+	0.0	0.0	0.0	0.0


### PR DESCRIPTION
Example output for the new OrthoFinder module in MultiQC/MultiQC#3634.

Adds `data/modules/orthofinder/Results_Mycoplasma_v3.1.5/Comparative_Genomics_Statistics/` containing the two files the module parses:

- `Statistics_Overall.tsv`
- `Statistics_PerSpecies.tsv`

They come from a full OrthoFinder 3.1.5 run on the four Mycoplasma proteomes that OrthoFinder itself ships as `ExampleData`, so the data is public and small (152 lines total). Both files are CRLF, as OrthoFinder writes them.

Note for anyone regenerating this: OrthoFinder 3 only writes `Comparative_Genomics_Statistics/` when the run continues past orthogroup inference. A run stopped with `-og` produces no such directory.
