### PR TITLE
Add 66-char width JCVI genestats test fixture (MultiQC/MultiQC#3614)

### DIFF
--- a/data/modules/jcvi/only_genestats/fourth
+++ b/data/modules/jcvi/only_genestats/fourth
@@ -1,0 +1,16 @@
+==================================================================
+                                                   o           all
+------------------------------------------------------------------
+                  Max number of transcripts per gene             4
+                                      Mean exon size        1059.5
+           Mean gene locus size (first to last exon)        5984.9
+              Mean number of distinct exons per gene           3.8
+                 Mean number of transcripts per gene           1.2
+                     Mean transcript size (UTR, CDS)        3543.1
+                            Number of distinct exons           204
+                                     Number of genes            53
+Number of genes with alternative transcript variants      4 (7.5%)
+                          Number of multi-exon genes    48 (90.6%)
+                     Number of predicted transcripts            61
+                         Number of single-exon genes      5 (9.4%)
+------------------------------------------------------------------


### PR DESCRIPTION
### Description of changes

Adds a test fixture (`fourth`) under `data/modules/jcvi/only_genestats/` with a 66-character table width.

This supports the fix in MultiQC/MultiQC#3614, where dynamic table sizing in upstream JCVI causes variation in the header and separator border lengths.